### PR TITLE
Add descriptive error messages

### DIFF
--- a/freshclam/manager.c
+++ b/freshclam/manager.c
@@ -1300,6 +1300,7 @@ getfile_mirman (const char *srcfile, const char *destfile,
         if (write (fd, buffer, bread) != bread)
         {
             logg ("getfile: Can't write %d bytes to %s\n", bread, destfile);
+            logg ("getfile: %s\n", strerror (errno));
             close (fd);
             unlink (destfile);
             return FCE_DBDIRACCESS;
@@ -2783,7 +2784,11 @@ downloadmanager (const struct optstruct *opts, const char *hostname,
     if (mkdir (updtmpdir, 0755))
     {
         logg ("!Can't create temporary directory %s\n", updtmpdir);
-        logg ("Hint: The database directory must be writable for UID %d or GID %d\n", getuid (), getgid ());
+        logg ("!%s\n", strerror (errno));
+        if (errno == EACCES)
+        {
+            logg ("Hint: The database directory must be writable for UID %d or GID %d\n", getuid (), getgid ());
+        }
         return FCE_DBDIRACCESS;
     }
 

--- a/shared/output.c
+++ b/shared/output.c
@@ -354,7 +354,8 @@ int logg(const char *str, ...)
 #ifdef CL_THREAD_SAFE
             pthread_mutex_unlock(&logg_mutex);
 #endif
-            printf("ERROR: Can't open %s in append mode (check permissions!).\n", logg_file);
+            printf("ERROR: Can't open %s in append mode.\n", logg_file);
+            printf("ERROR: %s\n", strerror (errno));
             if(len > sizeof(buffer))
                 free(abuffer);
             return -1;


### PR DESCRIPTION
Particularly helpful for ENOSPC (No space left on device), which previously showed only "Can't create temporary directory _", "Can't write to _" and "Hint: Check permissions!". Retains all previous hints.
