### PR TITLE
Add missing const keyword in cl_update_hash()

### DIFF
--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -755,7 +755,7 @@ unsigned char *cl_sign_file_fp(FILE *fp, EVP_PKEY *pkey, char *alg, unsigned int
 EVP_PKEY *cl_get_pkey_file(char *keypath);
 
 void *cl_hash_init(const char *alg);
-int cl_update_hash(void *ctx, void *data, size_t sz);
+int cl_update_hash(void *ctx, const void *data, size_t sz);
 int cl_finish_hash(void *ctx, void *buf);
 void cl_hash_destroy(void *ctx);
 /* End of crypto/hashing functions */

--- a/libclamav/crypto.c
+++ b/libclamav/crypto.c
@@ -1088,7 +1088,7 @@ void *cl_hash_init(const char *alg)
     return (void *)ctx;
 }
 
-int cl_update_hash(void *ctx, void *data, size_t sz)
+int cl_update_hash(void *ctx, const void *data, size_t sz)
 {
     if (!(ctx) || !(data))
         return -1;


### PR DESCRIPTION
This aligns the signature for _cl_update_hash()_ with OpenSSL's _EVP_DigestUpdate()_ used by the implementation.
