### PR TITLE
Bugfix for Exclude UID settings

### DIFF
--- a/clamd/others.c
+++ b/clamd/others.c
@@ -809,7 +809,7 @@ onas_fan_checkowner (int pid, const struct optstruct *opts)
     STATBUF sb;
     const struct optstruct *opt;
 
-    if (!(opt = optget (opts, "OnAccessExcludeUID"))->enabled)
+    if (!(opt = optget (opts, "OnAccessExcludeUID"))->name)
         return 0;
 
     snprintf (path, sizeof (path), "/proc/%u", pid);


### PR DESCRIPTION
This corrects the behavior of OnAccessExcludeUID to accurately exclude the UID from OnAccess scanning (Ex: OnAccessExcludeUID 0)
