### PR TITLE
Update the man page to reflect exit code behavior

### DIFF
--- a/docs/man/freshclam.1.in
+++ b/docs/man/freshclam.1.in
@@ -103,7 +103,9 @@ HostID in the form of an UUID to use when submitting statistical information.
 .SH "RETURN CODES"
 Some return codes of freshclam can be overwritten with a built-in command EXIT_n which can be passed to \-\-on\-*\-execute, eg. \-\-on\-update\-execute=EXIT_1 will force freshclam to always return 1 after successful database update.
 .TP
-0 : Database is up\-to\-date or successfully updated.
+0 : Database successfully updated.
+.TP
+1 : Database is up\-to\-date.
 .TP 
 40: Unknown option passed.
 .TP 


### PR DESCRIPTION
`freshclam` returns status 1, not 0, when the database is up-to-date as per the following line:  
https://github.com/vrtadmin/clamav-devel/blob/master/freshclam/manager.c#L2896
