### PR TITLE
OnAccessExtraScanning: log only in verbose mode

### DIFF
--- a/clamd/onaccess_scth.c
+++ b/clamd/onaccess_scth.c
@@ -133,10 +133,10 @@ void *onas_scan_th(void *arg) {
 	sigaction(SIGSEGV, &act, NULL);
 
 	if (tharg->options & ONAS_SCTH_ISDIR) {
-		logg("ScanOnAccess: Performing additional scanning on directory '%s'\n", tharg->pathname);
+		logg("*ScanOnAccess: Performing additional scanning on directory '%s'\n", tharg->pathname);
 		onas_scth_handle_dir(tharg->pathname, tharg);
 	} else if (tharg->options & ONAS_SCTH_ISFILE) {
-		logg("ScanOnAccess: Performing additional scanning on file '%s'\n", tharg->pathname);
+		logg("*ScanOnAccess: Performing additional scanning on file '%s'\n", tharg->pathname);
 		onas_scth_handle_file(tharg->pathname, tharg);
 	}
 


### PR DESCRIPTION
Before this patch, if OnAccessExtraScanning was active, every
file/directory access would have generate a log line.