### PR TITLE
Fix broken zlib version detect

### DIFF
--- a/configure
+++ b/configure
@@ -18718,9 +18718,9 @@ then
     as_fn_error $? "Please install zlib and zlib-devel packages" "$LINENO" 5
 else
 
-    vuln=`grep "ZLIB_VERSION \"1.2.0" $ZLIB_HOME/include/zlib.h`
+    vuln=`grep "ZLIB_VERSION \"1.2.0\"" $ZLIB_HOME/include/zlib.h`
     if test -z "$vuln"; then
-	vuln=`grep "ZLIB_VERSION \"1.2.1" $ZLIB_HOME/include/zlib.h`
+	vuln=`grep "ZLIB_VERSION \"1.2.1\"" $ZLIB_HOME/include/zlib.h`
     fi
 
     if test -n "$vuln"; then


### PR DESCRIPTION
A new zlib version 1.2.10 was released and is being detected as broken
due to the way version is checked. Add extra quote to the end of search
string to match entire version from zlib.h and fix false positive