### PR TITLE
Move help before config file check, so it actually works

### DIFF
--- a/clamdscan/clamdscan.c
+++ b/clamdscan/clamdscan.c
@@ -74,6 +74,12 @@ int main(int argc, char **argv)
 	return 2;
     }
 
+    if(optget(opts, "help")->enabled) {
+	optfree(opts);
+	optfree(clamdopts);
+    	help();
+    }
+
     if((clamdopts = optparse(optget(opts, "config-file")->strarg, 0, NULL, 1, OPT_CLAMD, 0, NULL)) == NULL) {
 	logg("!Can't parse clamd configuration file %s\n", optget(opts, "config-file")->strarg);
 	return 2;
@@ -95,12 +101,6 @@ int main(int argc, char **argv)
 	optfree(opts);
 	optfree(clamdopts);
 	exit(0);
-    }
-
-    if(optget(opts, "help")->enabled) {
-	optfree(opts);
-	optfree(clamdopts);
-    	help();
     }
 
     if(optget(opts, "infected")->enabled)


### PR DESCRIPTION
Currently, if there isn't a clamd.conf in the default location (which there never will be, if following the documentation for setting up clamd, since it suggests setting up a per-service daemon), it'll print this error:

```bash
ERROR: Can't parse clamd configuration file /etc/clamd.conf
```

Moving help option above that check fixes the problem.