### PR TITLE
Add new command `ALLMATCHSTREAM`

### DIFF
--- a/clamd/others.h
+++ b/clamd/others.h
@@ -35,7 +35,8 @@ enum mode {
     MODE_COMMAND,
     MODE_STREAM,
     MODE_WAITREPLY,
-    MODE_WAITANCILL
+    MODE_WAITANCILL,
+    MODE_STREAMALL,
 };
 
 struct fd_buf {

--- a/clamd/scanner.h
+++ b/clamd/scanner.h
@@ -58,6 +58,7 @@ struct cb_context {
 };
 
 int scanfd(const client_conn_t *conn, unsigned long int *scanned, const struct cl_engine *engine, unsigned int options, const struct optstruct *opts, int odesc, int stream);
+int scanfd_all(const client_conn_t *conn, unsigned long int *scanned, const struct cl_engine *engine, int odesc, int stream, const struct scan_cb_data *scandata);
 int scanstream(int odesc, unsigned long int *scanned, const struct cl_engine *engine, unsigned int options, const struct optstruct *opts, char term);
 int scan_callback(STATBUF *sb, char *filename, const char *msg, enum cli_ftw_reason reason, struct cli_ftw_cbdata *data);
 int scan_pathchk(const char *path, struct cli_ftw_cbdata *data);

--- a/clamd/session.c
+++ b/clamd/session.c
@@ -614,9 +614,6 @@ int execute_or_dispatch_command(client_conn_t *conn, enum commands cmd, const ch
 	    }
 	case COMMAND_ALLMATCHSTREAM:
         {
-		int rc = cli_gentempfd(optget(conn->opts, "TemporaryDirectory")->strarg, &conn->filename, &conn->scanfd);
-		if (rc != CL_SUCCESS)
-		    return rc;
 		conn->quota = optget(conn->opts, "StreamMaxLength")->numarg;
 		conn->mode = MODE_STREAMALL;
 		return 0;

--- a/clamd/session.h
+++ b/clamd/session.h
@@ -45,6 +45,7 @@
 #define CMD20 "DETSTATS"
 
 #define CMD21 "ALLMATCHSCAN"
+#define CMD22 "ALLMATCHSTREAM"
 
 #include "libclamav/clamav.h"
 #include "shared/optparser.h"
@@ -68,13 +69,15 @@ enum commands {
     /* new proto commands */
     COMMAND_IDSESSION,
     COMMAND_INSTREAM,
+    COMMAND_ALLMATCHSTREAM,
     COMMAND_COMMANDS,
     COMMAND_DETSTATSCLEAR,
     COMMAND_DETSTATS,
     /* internal commands */
     COMMAND_MULTISCANFILE,
     COMMAND_INSTREAMSCAN,
-    COMMAND_ALLMATCHSCAN
+    COMMAND_ALLMATCHSCAN,
+    COMMAND_ALLMATCHSTREAMSCAN,
 };
 
 typedef struct client_conn_tag {


### PR DESCRIPTION
This new command combines the `INSTREAM` functionality to scan from a stream and the 
 `ALLMATCHSCAN` functionality to retrieve all matches for a scan, and thus not stopping at the first match. 