### PR TITLE
Make milter to respect $THREAD_LIBS instead of force -lpthread

### DIFF
--- a/m4/reorganization/milter/check.m4
+++ b/m4/reorganization/milter/check.m4
@@ -5,7 +5,7 @@ if test "$have_milter" = "yes"; then
 
     dnl Check for libmilter and it's header files in the usual locations
     save_LIBS="$LIBS"
-    CLAMAV_MILTER_LIBS="$CLAMAV_MILTER_LIBS -lpthread"
+    CLAMAV_MILTER_LIBS="$CLAMAV_MILTER_LIBS $THREAD_LIBS"
     if test -d /usr/lib/libmilter ; then
 	CLAMAV_MILTER_LIBS="$CLAMAV_MILTER_LIBS -L/usr/lib/libmilter"
     fi


### PR DESCRIPTION
On generated configure clamav-milter is being forced to link using `-lpthread` instead of respecting a possible different thread library defined on `$THREAD_LIBS`. A current example of OS that doesn't support `-lpthread` is FreeBSD, that uses `-lthr`.