### PR TITLE
B11965:  Correct size of erroroffset on 64bit

### DIFF
--- a/libclamav/regex_pcre.c
+++ b/libclamav/regex_pcre.c
@@ -112,7 +112,8 @@ int cli_pcre_addoptions(struct cli_pcre_data *pd, const char **opt, int errout)
 #if USING_PCRE2
 int cli_pcre_compile(struct cli_pcre_data *pd, long long unsigned match_limit, long long unsigned match_limit_recursion, unsigned int options, int opt_override)
 {
-    int errornum, erroffset;
+    int errornum;
+    size_t erroffset;
     pcre2_general_context *gctx;
     pcre2_compile_context *cctx;
 


### PR DESCRIPTION
`erroroffset` is a pointer to `PCRE2_SIZE` type which according to the header file `pcre2-10.30/src/pcre2.h` is `#define PCRE2_SIZE size_t`. 

`size_t` on the amd64 architecture is 64 bits, so `erroroffset` cannot be an `int`.

Change `erroroffset` to `size_t` so it's always correct for all architectures.

Originally reported at https://bugs.gentoo.org/638932
Patch created by Jiří Moravec qjim@volny.cz