### PR TITLE
pdf: fix octal conversion in pdf_readstring.

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -1281,12 +1281,14 @@ static void pdf_parse_encrypt(struct pdf_struct *pdf, const char *enc, int len)
     uint32_t objid;
 
     if (len >= 16 && !strncmp(enc, "/EncryptMetadata", 16)) {
-        q = cli_memstr(enc+16, len-16, "/Encrypt", 8);
-        if (!q)
-            return;
+        do {
+            q = cli_memstr(enc + 16, len - 16, "/Encrypt", 8);
+            if (!q)
+              return;
 
-        len -= q - enc;
-        enc = q;
+           len -= q - enc;
+           enc = q;
+        } while (len >= 8 && *(enc+8) == 'M');
     }
 
     q = enc + 8;

--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -1748,10 +1748,11 @@ static char *pdf_readstring(const char *q0, int len, const char *key, unsigned *
                     case '8':
                     case '9':
                         /* octal escape */
-                        if (q+2 < end)
-                            q++;
+                        if (q+2 < end) {
+                            *s++ = 64*(q[0] - '0') + 8*(q[1] - '0') + (q[2] - '0');
+                            q++; q++;
+                        }
 
-                        *s++ = 64*(q[0] - '0') + 8*(q[1] - '0') + (q[2] - '0');
                         break;
                     default:
                         /* ignore */
@@ -2191,8 +2192,9 @@ void pdf_handle_enc(struct pdf_struct *pdf)
         n = 0;
         O = pdf_readstring(q, len, "/O", &n, NULL, 0);
         if (!O || n < oulen) {
-            cli_dbgmsg("cli_pdf: invalid O: %d\n", n);
-            cli_dbgmsg("cli_pdf: invalid O: %d\n", n);
+            cli_dbgmsg("cli_pdf: invalid O: %u\n", n);
+            noisy_warnmsg("cli_pdf: invalid O: %u\n", n);
+
             if (O)
                 dbg_printhex("invalid O", O, n);
 
@@ -2228,6 +2230,7 @@ void pdf_handle_enc(struct pdf_struct *pdf)
                     break;
             if (i != n) {
                 dbg_printhex("too long U", U, n);
+                noisy_warnmsg("too long U: %u", n);
                 break;
             }
         }


### PR DESCRIPTION
pdf: fix octal conversion in pdf_readstring.

Example of /O from /Encrypt section which wasn't properly parsed and which was producing Heuristics.Encrypted.PDF:

`/O (6E\033\323\235u;|\035\020\222,\(\346fZ\244\3635?\2604\213Sh\223\343\261\333\\W\233)`

Without the fix:

```
LibClamAV debug: cli_pdf: too long O: 36450433c4332d35753b7c1435ac308c322c286636665a4c349d33353f8430347b335368c4334433b43104335c57d133
LibClamAV debug: cli_pdf: encrypted pdf found, not decryptable, stream will probably fail to decompress!
```


With the fix:

```
LibClamAV debug: cli_pdf: Encrypt R: 3, P fffffae4, length: 128
LibClamAV debug: cli_pdf: U: : 26200c96dd2d34a65928aa073f0360aadaeb6deef3b8a38496fb422a428d2052
LibClamAV debug: cli_pdf: O: : 36451bd39d753b7c1d10922c28e6665aa4f3353fb0348b536893e3b1db5c579b
LibClamAV debug: cli_pdf: md5: ...
LibClamAV debug: cli_pdf: Candidate encryption key: ...
LibClamAV debug: cli_pdf: fileID: ...
LibClamAV debug: cli_pdf: computed U (R>=3): ...
LibClamAV debug: cli_pdf: user password is empty
LibClamAV debug: cli_pdf: encrypted pdf found, decryptable!
```