### PR TITLE
libclamav: explicitly use top_srcdir .git dir

### DIFF
--- a/libclamav/Makefile.am
+++ b/libclamav/Makefile.am
@@ -616,7 +616,7 @@ version.h: version.h.tmp
 version.h.tmp:
 	$(AM_V_GEN) test -f version.h || touch version.h;\
 	rm -f $@;\
-	REVISION="$$(LANG=C cd "$(top_srcdir)"; git describe --always 2>/dev/null || echo "exported")";\
+	REVISION="$$(LANG=C git --git-dir "$(top_srcdir)"/.git describe --always 2>/dev/null || echo "exported")";\
 	if test "$$REVISION" = "exported"; then\
 	    REVISION="";\
 	fi;\

--- a/libclamav/Makefile.in
+++ b/libclamav/Makefile.in
@@ -3777,7 +3777,7 @@ version.h: version.h.tmp
 version.h.tmp:
 	$(AM_V_GEN) test -f version.h || touch version.h;\
 	rm -f $@;\
-	REVISION="$$(LANG=C cd "$(top_srcdir)"; git describe --always 2>/dev/null || echo "exported")";\
+	REVISION="$$(LANG=C git --git-dir "$(top_srcdir)"/.git describe --always 2>/dev/null || echo "exported")";\
 	if test "$$REVISION" = "exported"; then\
 	    REVISION="";\
 	fi;\


### PR DESCRIPTION
This will prevent git from picking up a ref from parent git repository
and setting this as libclamav REVISION/version.