### PR TITLE
Add configure option to force enable mmap support while cross compiling

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -3695,7 +3695,7 @@ static cl_error_t scan_common(int desc, cl_fmap_t *map, const char *filepath, co
         if (FSTAT(desc, &sb))
             return CL_ESTAT;
 
-        if ((size_t)(sb.st_size) > (size_t)(INT_MAX - 2))
+        if ((unsigned long long)(sb.st_size) > (unsigned long long)(INT_MAX - 2))
             return CL_CLEAN;
     }
 

--- a/m4/mmap_private.m4
+++ b/m4/mmap_private.m4
@@ -1,3 +1,4 @@
+AC_ARG_ENABLE([mmap-for-cross-compiling],[AS_HELP_STRING([--enable-mmap-for-cross-compiling], [set to "yes" to force enable mmap support without checking under cross-compiling. This could help enable mempool feature.])], enable_mmap_for_cross_compiling=$enableval, mmap_for_cross_compiling="no")
 dnl Check for mmap()
 dnl AC_FUNC_MMAP checks for private fixed mappings, we don't need
 dnl fixed mappings, so check only wether private mappings work.
@@ -67,7 +68,13 @@ int main(void)
 }])],
 	[ac_cv_c_mmap_private=yes],
 	[ac_cv_c_mmap_private=no],
-	[ac_cv_c_mmap_private=no])])
+	[
+	if test $enable_mmap_for_cross_compiling = yes; then
+  ac_cv_c_mmap_private=yes
+	else
+  ac_cv_c_mmap_private=no
+	fi
+	])])
 if test $ac_cv_c_mmap_private = yes; then
 	AC_DEFINE(HAVE_MMAP, 1,
 		[Define to 1 if you have a working `mmap' system call that supports MAP_PRIVATE.])


### PR DESCRIPTION
    - If cross-compiling platform like ARM, the mmap support will be
      disabled directly, which indirectly disabled mempool function, too.
      Without mempool, the engine initialization time will be very long
      due to memory fragmentation. The fragmentation problem will make
      heap grow very fast, and results in using a lot of swap while
      running on low RAM machines. It will slow down initialization
      and scanning process.
    - Test result:
      The initialization time of using memory pool on 256MB ARM machine is
      faster than without mempool by 5-hour.