### PR TITLE
header files cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,8 @@ EXTRA_DIST = examples shared libclamav.pc.in COPYING.bzip2 COPYING.lzma COPYING.
 
 bin_SCRIPTS=clamav-config
 
+pkginclude_HEADERS = clamav-config.h platform.h
+
 if ENABLE_CLAMSUBMIT
 SUBDIRS += clamsubmit
 endif

--- a/clamav-config.in
+++ b/clamav-config.in
@@ -3,7 +3,7 @@
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
-includedir=@includedir@
+includedir=@includedir@/clamav
 libdir=@libdir@
 
 usage()
@@ -55,7 +55,7 @@ while test $# -gt 0; do
 	;;
 
     --cflags)
-       	echo -I@includedir@ @CFLAGS@
+           echo -I${includedir} @CFLAGS@
        	;;
 
     --libs)

--- a/libclamav.pc.in
+++ b/libclamav.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/clamav
 
 Name: libclamav
 Description: A GPL virus scanner

--- a/libclamav/Makefile.am
+++ b/libclamav/Makefile.am
@@ -269,7 +269,7 @@ if VERSIONSCRIPT
 libclamav_la_LDFLAGS += -Wl,@VERSIONSCRIPTFLAG@,@top_srcdir@/libclamav/libclamav.map
 endif
 
-pkginclude_HEADERS = clamav.h
+pkginclude_HEADERS = clamav.h cltypes.h
 
 libclamav_la_SOURCES = \
         matcher-ac.c \

--- a/libclamav/Makefile.am
+++ b/libclamav/Makefile.am
@@ -269,7 +269,7 @@ if VERSIONSCRIPT
 libclamav_la_LDFLAGS += -Wl,@VERSIONSCRIPTFLAG@,@top_srcdir@/libclamav/libclamav.map
 endif
 
-include_HEADERS = clamav.h
+pkginclude_HEADERS = clamav.h
 
 libclamav_la_SOURCES = \
         matcher-ac.c \


### PR DESCRIPTION
Commit 048a88e61558726bd9ba66ec3195b63d61d8a430 reworked number of internal structures and also unconditionally included "cltypes.h" in "clamav.h". "cltypes.h" includes "clamav-config.h" which includes "platform.h".

We need these files installed in order to allow third-party tools (e.g. cyrus-imapd) to build. 

Since platform.h is a common name, in order to avoit potential filename conflict, put all header files into separate namespace dir (includedir/clamav) and update pkgconfig and clamav-config to report this new path. 