### PR TITLE
pdf: fix octal conversion in pdf_readstring.

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2360,8 +2360,8 @@ static const char *pdf_getdict(const char *q0, int *len, const char *key)
     }
 
     /* if the value is a dictionary object, include the < > brackets.*/
-    if (q[-1] == '<')
-        q--;
+    while (q > q0 && (q[-1] == '<' || q[-1] == '\n'))
+      q--;
 
     *len -= q - q0;
     return q;
@@ -2493,6 +2493,11 @@ static char *pdf_readstring(const char *q0, int len, const char *key, unsigned *
     if ((*q == '<') && (len >= 3)) {
         start = ++q;
         len -= 1;
+        // skip newlines after <
+        while (len > 0 && *start == '\n') {
+          start = ++q;
+          len -= 1;
+        }
         q = memchr(q + 1, '>', len - 1);
         if (!q)
             return NULL;

--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2468,10 +2468,10 @@ static char *pdf_readstring(const char *q0, int len, const char *key, unsigned *
                         case '8':
                         case '9':
                             /* octal escape */
-                            if (q + 2 < end)
-                                q++;
-
-                            *s++ = 64 * (q[0] - '0') + 8 * (q[1] - '0') + (q[2] - '0');
+                            if (q + 2 < end) {
+                                *s++ = 64*(q[0] - '0') + 8*(q[1] - '0') + (q[2] - '0');
+                                q++; q++;
+                            }
                             break;
                         default:
                             /* ignore */


### PR DESCRIPTION
Fix parsing of octal value found while debugging buggy Heuristics.Encrypted.PDF detection.
 
Example of /O from /Encrypt section which wasn't properly parsed and which was producing Heuristics.Encrypted.PDF:

`/O (6E\033\323\235u;|\035\020\222,\(\346fZ\244\3635?\2604\213Sh\223\343\261\333\\W\233)`

Without the fix:

```
$ clamscan --block-encrypted=yes --debug foo.pdf
...
LibClamAV debug: in cli_pdf(/tmp/clamav-7ff235b222d256b0594d496c33108511.tmp)
LibClamAV debug: cli_pdf: Encrypt dictionary in obj 30 0
LibClamAV debug: cli_pdf: found xref
LibClamAV debug: Bytecode executing hook id 258 (2 hooks)
LibClamAV debug: Bytecode 18: executing in interpreter mode
LibClamAV debug: bytecode: registered ctx variable at 0x560f2efe3e48 (+256) id 6
LibClamAV debug: Bytecode 24 returned 0
LibClamAV debug: Bytecode: executed 2 bytecodes for this hook
...
LibClamAV debug: cli_pdf: 29 0 obj flags: 02
LibClamAV debug: cli_pdf: 30 0 obj flags: 230002
LibClamAV debug: cli_pdf: too long O: 36450433c4332d35753b7c1435ac308c322c286636665a4c349d33353f8430347b335368c4334433b43104335c57d133
LibClamAV debug: cli_pdf: encrypted pdf found, not decryptable, stream will probably fail to decompress!
LibClamAV debug: FP SIGNATURE: 87dd65ce5939e63f00d7ddefc914df58:75150:Heuristics.Encrypted.PDF
foo.pdf: Heuristics.Encrypted.PDF FOUND

```
/O and /U objects aren't correctly parsed. With the following fix, I don't get the heuristic detection anymore and I get the following debug messages from the parser which are more accurate:

```
LibClamAV debug: cli_pdf: Encrypt R: 3, P fffffae4, length: 128
LibClamAV debug: cli_pdf: U: : 26200c96dd2d34a65928aa073f0360aadaeb6deef3b8a38496fb422a428d2052
LibClamAV debug: cli_pdf: O: : 36451bd39d753b7c1d10922c28e6665aa4f3353fb0348b536893e3b1db5c579b
LibClamAV debug: cli_pdf: md5: e6565f5df62ab42680601d48f841a052
LibClamAV debug: cli_pdf: Candidate encryption key: e6565f5df62ab42680601d48f841a052
LibClamAV debug: cli_pdf: fileID: b3e3839f44c83df1a9e4fd8f9628236c
LibClamAV debug: cli_pdf: computed U (R>=3): 26200c96dd2d34a65928aa073f0360aa
LibClamAV debug: cli_pdf: user password is empty
LibClamAV debug: cli_pdf: encrypted pdf found, decryptable!
```