### PR TITLE
remove private header cltypes.h from clamav.h

### DIFF
--- a/libclamav/clamav.h
+++ b/libclamav/clamav.h
@@ -65,8 +65,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#include "cltypes.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
cltypes.h should not be included with the libclamav API