### PR TITLE
fix failure of large file detection on 32-bit platforms

### DIFF
--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -3695,7 +3695,7 @@ static cl_error_t scan_common(int desc, cl_fmap_t *map, const char *filepath, co
         if (FSTAT(desc, &sb))
             return CL_ESTAT;
 
-        if ((size_t)(sb.st_size) > (size_t)(INT_MAX - 2))
+        if ((unsigned long long)(sb.st_size) > (unsigned long long)(INT_MAX - 2))
             return CL_CLEAN;
     }
 


### PR DESCRIPTION
With FILE_OFFSET_BITS=64, st_size is 8-byte.
In this case, casting st_size to size_t, which is 4-byte on 32-bit machine,
will make the comparison go wrong.

Signed-off-by: rickwang <rickwang@synology.com>