### PR TITLE
Update sigtool.c

### DIFF
--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -1749,6 +1749,7 @@ static int vbadump(const struct optstruct *opts)
         destroy_ctx(-1, ctx);
         cli_rmdirs(dir);
         free(dir);
+        close(fd);
         return -1;
     }
     destroy_ctx(-1, ctx);
@@ -1756,6 +1757,7 @@ static int vbadump(const struct optstruct *opts)
         sigtool_vba_scandir(dir, hex_output, vba);
     cli_rmdirs(dir);
     free(dir);
+    close(fd);
     return 0;
 }
 


### PR DESCRIPTION
- fix bug: fd open but no close,it makes handle is occupied

- The other problem which is worth discussing is  line1748  in sigtool.c
```
    if (!(ctx = convenience_ctx(fd))) {
        close(fd);
        free(dir);
        return -1;
    }
    if (cli_ole2_extract(dir, ctx, &vba)) {
        destroy_ctx(-1, ctx);
        cli_rmdirs(dir);
        free(dir);
        close(fd);
        return -1;
    }
```
i think cli_ole2_extract need to be judged by specific requirement clearly because when ctx is null  it will step in if branch and try to destroy null that will cause crash. it not a good design.Although it is be confirmed not null in line1743.