### PR TITLE
pdf: handle dictionary object with newlines.

### DIFF
--- a/libclamav/pdf.c
+++ b/libclamav/pdf.c
@@ -2360,8 +2360,8 @@ static const char *pdf_getdict(const char *q0, int *len, const char *key)
     }
 
     /* if the value is a dictionary object, include the < > brackets.*/
-    if (q[-1] == '<')
-        q--;
+    while (q > q0 && (q[-1] == '<' || q[-1] == '\n'))
+      q--;
 
     *len -= q - q0;
     return q;
@@ -2493,6 +2493,11 @@ static char *pdf_readstring(const char *q0, int len, const char *key, unsigned *
     if ((*q == '<') && (len >= 3)) {
         start = ++q;
         len -= 1;
+        // skip newlines after <
+        while (len > 0 && *start == '\n') {
+          start = ++q;
+          len -= 1;
+        }
         q = memchr(q + 1, '>', len - 1);
         if (!q)
             return NULL;


### PR DESCRIPTION
Handle protected PDF with `/O<` followed by newline.

```
<<
/Filter/Standard/O<
ae5957c6056d6cb851f8cae0d7f919e85d6425ed485b865fa0fdba7e98e39b81>/U<
be05fcbacb29c18cc3568c8e8832a99900000000000000000000000000000000>
/P -2359324/V 2/R 3/Length 128
>>
```