### PR TITLE
systemd - set TimeoutStartSec=240 for clamav-daemon

### DIFF
--- a/clamd/clamav-daemon.service.in
+++ b/clamd/clamav-daemon.service.in
@@ -11,6 +11,7 @@ ExecStart=@prefix@/sbin/clamd --foreground=true
 # Reload the database
 ExecReload=/bin/kill -USR2 $MAINPID
 StandardOutput=syslog
+TimeoutStartSec=240
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
clamd can take quite a long time to start - especially on VM guests with multiple guests starting up at once.  This has been sufficient for me.