### PR TITLE
add Hygon Dhyana support for clamav

### DIFF
--- a/libclamav/c++/llvm/lib/System/Host.cpp
+++ b/libclamav/c++/llvm/lib/System/Host.cpp
@@ -291,6 +291,14 @@ std::string sys::getHostCPUName() {
     default:
       return "generic";
     }
+  } else if (memcmp(text.c, "HygonGenuine", 12) == 0) {
+    switch (Family) {
+    case 24: //family 18h
+      return "dhyana";
+    default:
+      return "generic";
+    }
+    return "generic";
   }
   return "generic";
 }

--- a/libclamav/c++/llvm/lib/Target/X86/X86.td
+++ b/libclamav/c++/llvm/lib/Target/X86/X86.td
@@ -148,6 +148,8 @@ def : Proc<"istanbul",        [Feature3DNowA, Feature64Bit, FeatureSSE4A,
                                Feature3DNowA]>;
 def : Proc<"shanghai",        [Feature3DNowA, Feature64Bit, FeatureSSE4A,
                                Feature3DNowA]>;
+def : Proc<"dhyana",          [Feature3DNowA, Feature64Bit, FeatureSSE42,
+                               FeatureAVX]>;
 
 def : Proc<"winchip-c6",      [FeatureMMX]>;
 def : Proc<"winchip2",        [FeatureMMX, Feature3DNow]>;

--- a/libclamav/c++/llvm/lib/Target/X86/X86Subtarget.cpp
+++ b/libclamav/c++/llvm/lib/Target/X86/X86Subtarget.cpp
@@ -259,13 +259,14 @@ void X86Subtarget::AutoDetectSubtargetFeatures() {
 
   bool IsIntel = memcmp(text.c, "GenuineIntel", 12) == 0;
   bool IsAMD   = !IsIntel && memcmp(text.c, "AuthenticAMD", 12) == 0;
+  bool IsHygon = memcmp(text.c, "HygonGenuine", 12) == 0;
 
   HasCLMUL = IsIntel && ((ECX >> 1) & 0x1);
   HasFMA3  = IsIntel && ((ECX >> 12) & 0x1);
   HasAVX   = ((ECX >> 28) & 0x1);
   HasAES   = IsIntel && ((ECX >> 25) & 0x1);
 
-  if (IsIntel || IsAMD) {
+  if (IsIntel || IsAMD || IsHygon) {
     // Determine if bit test memory instructions are slow.
     unsigned Family = 0;
     unsigned Model  = 0;
@@ -277,8 +278,8 @@ void X86Subtarget::AutoDetectSubtargetFeatures() {
 
     GetCpuIDAndInfo(0x80000001, &EAX, &EBX, &ECX, &EDX);
     HasX86_64 = (EDX >> 29) & 0x1;
-    HasSSE4A = IsAMD && ((ECX >> 6) & 0x1);
-    HasFMA4 = IsAMD && ((ECX >> 16) & 0x1);
+    HasSSE4A = (IsAMD||IsHygon) && ((ECX >> 6) & 0x1);
+    HasFMA4 = (IsAMD||IsHygon) && ((ECX >> 16) & 0x1);
   }
 }
 


### PR DESCRIPTION
To add Hygon Dhyana support in Clamav, we add in following parts:
* add dhyana detection in function sys::getHostCPUName() and X86Subtarget::AutoDetectSubtargetFeatures()
* add dhyana define in llvm/lib/Target/X86/X86.td