### PR TITLE
Fix buffer length check

### DIFF
--- a/libclamav/matcher-byte-comp.c
+++ b/libclamav/matcher-byte-comp.c
@@ -583,16 +583,13 @@ cl_error_t cli_bcomp_compare_check(const unsigned char *f_buffer, size_t buffer_
     opt      = bm->options;
 
     /* ensure we won't run off the end of the file buffer */
-    if (bm->offset > 0) {
-        if (!((offset + bm->offset + byte_len <= length))) {
-            bcm_dbgmsg("cli_bcomp_compare_check: %u bytes requested at offset %zu would go past file buffer of %u\n", byte_len, (offset + bm->offset), length);
-            return CL_CLEAN;
-        }
-    } else {
-        if (!(offset + bm->offset > 0)) {
-            bcm_dbgmsg("cli_bcomp_compare_check: negative offset would underflow buffer\n");
-            return CL_CLEAN;
-        }
+    if (!(offset + bm->offset + byte_len <= length)) {
+        bcm_dbgmsg("cli_bcomp_compare_check: %u bytes requested at offset %zu would go past file buffer of %u\n", byte_len, (offset + bm->offset), length);
+        return CL_CLEAN;
+    }
+    if (!(offset + bm->offset > 0)) {
+        bcm_dbgmsg("cli_bcomp_compare_check: negative offset would underflow buffer\n");
+        return CL_CLEAN;
     }
 
     /* jump to byte compare offset, then store off specified bytes into a null terminated buffer */


### PR DESCRIPTION
It is possible for `bm->offset` to be <= 0 and `(offset + bm->offset)` to be > 0, in which case the bounds check was incorrectly skipped, sometimes resulting in a segfault.

```
    Program terminated with signal SIGSEGV, Segmentation fault.
    #0  0x00007fea90598db0 in cli_bcomp_compare_check (
        f_buffer=0x7fea5c9e3a3e <error: Cannot access memory at address 0x7fea5c9e3a3e>, f_buffer@entry=0x7fea5c98c1ba "\001\030\001\030",
        buffer_length=buffer_length@entry=2590, offset=<optimized out>,
        bm=bm@entry=0x7fea7289f9c8) at matcher-byte-comp.c:720
```