### PR TITLE
onas_...cleanup function return void pointer remove

### DIFF
--- a/clamonacc/clamonacc.c
+++ b/clamonacc/clamonacc.c
@@ -384,13 +384,13 @@ void help(void)
     exit(0);
 }
 
-void *onas_cleanup(struct onas_context *ctx)
+void onas_cleanup(struct onas_context *ctx)
 {
     onas_context_cleanup(ctx);
     logg_close();
 }
 
-void *onas_context_cleanup(struct onas_context *ctx)
+void onas_context_cleanup(struct onas_context *ctx)
 {
     close(ctx->fan_fd);
     optfree((struct optstruct *)ctx->opts);

--- a/clamonacc/clamonacc.h
+++ b/clamonacc/clamonacc.h
@@ -76,8 +76,8 @@ struct onas_context {
 #endif
 
 struct onas_context *onas_init_context(void);
-void *onas_cleanup(struct onas_context *ctx);
-void *onas_context_cleanup(struct onas_context *ctx);
+void onas_cleanup(struct onas_context *ctx);
+void onas_context_cleanup(struct onas_context *ctx);
 cl_error_t onas_check_client_connection(struct onas_context **ctx);
 int onas_start_eloop(struct onas_context **ctx);
 void help(void);


### PR DESCRIPTION
The functions 
onas_cleanup()
onas_context_cleanup()
doesn't return anything so we need type void and not void*.