### PR TITLE
etc: cleanup config files for standard terminal width

### DIFF
--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -150,7 +150,7 @@ Example
 
 # This option specifies how long to wait (in milliseconds) if the send buffer
 # is full.
-# Keep this value low to prevent clamd hanging
+# Keep this value low to prevent clamd hanging.
 #
 # Default: 500
 #SendBufTimeout 200
@@ -161,7 +161,7 @@ Example
 # WARNING: you shouldn't increase this too much to avoid running out  of file
 # descriptors, the following condition should hold:
 # MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual
-# max is 1024)
+# max is 1024).
 #
 # Default: 100
 #MaxQueue 200
@@ -487,10 +487,9 @@ Example
 #MaxScanTime 300000
 
 # This option sets the maximum amount of data to be scanned for each input
-# file.
-# Archives and other containers are recursively extracted and scanned up to
-# this value.
-# Value of 0 disables the limit.
+# file. Archives and other containers are recursively extracted and scanned
+# up to this value.
+# Value of 0 disables the limit
 # Note: disabling this limit or setting it too high may result in severe damage
 # to the system.
 # Default: 100M

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -156,11 +156,10 @@ Example
 #SendBufTimeout 200
 
 # Maximum number of queued items (including those being processed by
-# MaxThreads threads)
+# MaxThreads threads).
 # It is recommended to have this value at least twice MaxThreads if possible.
 # WARNING: you shouldn't increase this too much to avoid running out  of file
-# descriptors,
-# the following condition should hold:
+# descriptors, the following condition should hold:
 # MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual
 # max is 1024)
 #
@@ -267,8 +266,8 @@ Example
 # When enabled, if a heuristic scan (such as phishingScan) detects
 # a possible virus/phish it will stop scan immediately. Recommended, saves CPU
 # scan-time.
-# When disabled, virus/phish detected by heuristic scans will be reported only at
-# the end of a scan. If an archive contains both a heuristically detected
+# When disabled, virus/phish detected by heuristic scans will be reported only
+# at the end of a scan. If an archive contains both a heuristically detected
 # virus/phish, and a real malware, the real malware will be reported
 #
 # Keep this disabled if you intend to handle "*.Heuristics.*" viruses
@@ -289,11 +288,13 @@ Example
 # Default: no
 #AlertBrokenExecutables yes
 
-# Alert on encrypted archives _and_ documents with heuristic signature (encrypted .zip, .7zip, .rar, .pdf).
+# Alert on encrypted archives _and_ documents with heuristic signature
+# (encrypted .zip, .7zip, .rar, .pdf).
 # Default: no
 #AlertEncrypted yes
 
-# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip, .rar).
+# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip,
+# .rar).
 # Default: no
 #AlertEncryptedArchive yes
 
@@ -477,10 +478,10 @@ Example
 
 # This option sets the maximum amount of time to a scan may take.
 # In this version, this field only affects the scan time of ZIP archives.
-# Value of 0 disables the limit
+# Value of 0 disables the limit.
 # Note: disabling this limit or setting it too high may result allow scanning
-# of certain files to lock up the scanning process/threads resulting in a Denial
-# of Service.
+# of certain files to lock up the scanning process/threads resulting in a
+# Denial of Service.
 # Time is in milliseconds.
 # Default: 120000
 #MaxScanTime 300000
@@ -489,7 +490,7 @@ Example
 # file.
 # Archives and other containers are recursively extracted and scanned up to
 # this value.
-# Value of 0 disables the limit
+# Value of 0 disables the limit.
 # Note: disabling this limit or setting it too high may result in severe damage
 # to the system.
 # Default: 100M
@@ -628,15 +629,17 @@ Example
 # Default: 5M
 #OnAccessMaxFileSize 10M
 
-# Max number of scanning threads to allocate to the OnAccess thread pool at startup.
-# These threads are the ones responsible for creating a connection with the daemon
-# and kicking off scanning after an event has been processed. To prevent clamonacc
-# from consuming all clamd's resources keep this lower than clamd's max threads.
+# Max number of scanning threads to allocate to the OnAccess thread pool at
+# startup. These threads are the ones responsible for creating a connection
+# with the daemon and kicking off scanning after an event has been processed.
+# To prevent clamonacc from consuming all clamd's resources keep this lower
+# than clamd's max threads.
 # Default: 5
 #OnAccessMaxThreads 10
 
-# Max amount of time (in milliseconds) that the OnAccess client should spend for every
-# connect, send, and recieve attempt when communicating with clamd via curl.
+# Max amount of time (in milliseconds) that the OnAccess client should spend
+# for every connect, send, and recieve attempt when communicating with clamd
+# via curl.
 # Default: 5000 (5 seconds)
 # OnAccessCurlTimeout 10000
 
@@ -662,10 +665,11 @@ Example
 # Default: no
 #OnAccessPrevention yes
 
-# When using prevention, if this option is turned on, any errors that occur during
-# scanning will result in the event attempt being denied. This could potentially
-# lead to unwanted system behaviour with certain configurations, so the client defaults
-# this to off and prefers allowing access events in case of scan or connection error.
+# When using prevention, if this option is turned on, any errors that occur
+# during scanning will result in the event attempt being denied. This could
+# potentially lead to unwanted system behaviour with certain configurations,
+# so the client defaults this to off and prefers allowing access events in
+# case of scan or connection error.
 # Default: no
 #OnAccessDenyOnError yes
 
@@ -677,10 +681,11 @@ Example
 
 # Set the  mount point to be scanned. The mount point specified, or the mount
 # point containing the specified directory will be watched. If any directories
-# are specified, this option will preempt (disable and ignore all options related to)
-# the DDD system. This option will result in verdicts only.
-# Note that prevention is explicitly disallowed to prevent common, fatal misconfigurations. (e.g.
-# watching "/" with prevention on and no exclusions made on vital system directories)
+# are specified, this option will preempt (disable and ignore all options
+# related to) the DDD system. This option will result in verdicts only.
+# Note that prevention is explicitly disallowed to prevent common, fatal
+# misconfigurations. (e.g. watching "/" with prevention on and no exclusions
+# made on vital system directories)
 # It can be used multiple times.
 # Default: disabled
 #OnAccessMountPath /
@@ -714,12 +719,13 @@ Example
 
 # This option allows exclusions via user names when using the on-access
 # scanning client. It can be used multiple times.
-# It has the same potential race condition limitations of the OnAccessExcludeUID option.
+# It has the same potential race condition limitations of the
+# OnAccessExcludeUID option.
 # Default: disabled
 #OnAccessExcludeUname clamav
 
-# Number of times the OnAccess client will retry a failed scan due to connection problems
-# (or other issues).
+# Number of times the OnAccess client will retry a failed scan due to
+# connection problems (or other issues).
 # Default: 0
 #OnAccessRetryAttempts 3
 
@@ -755,6 +761,3 @@ Example
 # Default: 5000
 # BytecodeTimeout 1000
 
-##
-## Statistics gathering and submitting
-##

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -188,7 +188,8 @@ DatabaseMirror database.clamav.net
 # option, it's mandatory to run freshclam at least every 30 minutes.
 # Freshclam uses the ClamAV's mirror infrastructure to distribute the
 # database and its updates but all the contents are provided under Google's
-# terms of use. See https://www.google.com/transparencyreport/safebrowsing
+# terms of use.
+# See https://transparencyreport.google.com/safe-browsing/overview
 # and https://www.clamav.net/documents/safebrowsing for more information.
 # Default: no
 #SafeBrowsing yes

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -90,11 +90,11 @@ DatabaseMirror database.clamav.net
 # This option can be used multiple times. Support for:
 #   http(s)://, ftp(s)://, or file://
 # Default: no custom URLs
-#DatabaseCustomURL http://myserver.com/mysigs.ndb
-#DatabaseCustomURL https://myserver.com/mysigs.ndb
-#DatabaseCustomURL https://myserver.com:4567/whitelist.wdb
-#DatabaseCustomURL ftp://myserver.com/example.ldb
-#DatabaseCustomURL ftps://myserver.com:4567/example.ndb
+#DatabaseCustomURL http://myserver.example.com/mysigs.ndb
+#DatabaseCustomURL https://myserver.example.com/mysigs.ndb
+#DatabaseCustomURL https://myserver.example.com:4567/whitelist.wdb
+#DatabaseCustomURL ftp://myserver.example.com/example.ldb
+#DatabaseCustomURL ftps://myserver.example.com:4567/example.ndb
 #DatabaseCustomURL file:///mnt/nfs/local.hdb
 
 # This option allows you to easily point freshclam to private mirrors.
@@ -107,15 +107,16 @@ DatabaseMirror database.clamav.net
 # and ScriptedUpdates. It can be used multiple times to provide
 # fall-back mirrors.
 # Default: disabled
-#PrivateMirror mirror1.mynetwork.com
-#PrivateMirror mirror2.mynetwork.com
+#PrivateMirror mirror1.example.com
+#PrivateMirror mirror2.example.com
 
 # Number of database checks per day.
 # Default: 12 (every two hours)
 #Checks 24
 
 # Proxy settings
-# The HTTPProxyServer may be prefixed with [scheme]:// to specify which kind of proxy is used.
+# The HTTPProxyServer may be prefixed with [scheme]:// to specify which kind
+# of proxy is used.
 #   http://     HTTP Proxy. Default when no scheme or proxy type is specified.
 #   https://    HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and NSS)
 #   socks4://   SOCKS4 Proxy.
@@ -123,7 +124,7 @@ DatabaseMirror database.clamav.net
 #   socks5://   SOCKS5 Proxy.
 #   socks5h://  SOCKS5 Proxy. Proxy resolves URL hostname.
 # Default: disabled
-#HTTPProxyServer https://myproxy.com
+#HTTPProxyServer https://proxy.example.com
 #HTTPProxyPort 1234
 #HTTPProxyUsername myusername
 #HTTPProxyPassword mypass
@@ -188,8 +189,7 @@ DatabaseMirror database.clamav.net
 # Freshclam uses the ClamAV's mirror infrastructure to distribute the
 # database and its updates but all the contents are provided under Google's
 # terms of use. See https://www.google.com/transparencyreport/safebrowsing
-# and https://www.clamav.net/documents/safebrowsing
-# for more information.
+# and https://www.clamav.net/documents/safebrowsing for more information.
 # Default: no
 #SafeBrowsing yes
 

--- a/win32/conf_examples/clamd.conf.sample
+++ b/win32/conf_examples/clamd.conf.sample
@@ -121,20 +121,23 @@ TCPAddr 127.0.0.1
 
 # This option specifies the time (in seconds) after which clamd should
 # timeout if a client doesn't provide any initial command after connecting.
-# Default: 5
-#CommandReadTimeout 5
+# Default: 30
+#CommandReadTimeout 30
 
-# This option specifies how long to wait (in milliseconds) if the send buffer is full.
-# Keep this value low to prevent clamd hanging
+# This option specifies how long to wait (in milliseconds) if the send buffer
+# is full.
+# Keep this value low to prevent clamd hanging.
 #
 # Default: 500
 #SendBufTimeout 200
 
-# Maximum number of queued items (including those being processed by MaxThreads threads)
+# Maximum number of queued items (including those being processed by
+# MaxThreads threads).
 # It is recommended to have this value at least twice MaxThreads if possible.
-# WARNING: you shouldn't increase this too much to avoid running out  of file descriptors,
-# the following condition should hold:
-# MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual max is 1024)
+# WARNING: you shouldn't increase this too much to avoid running out  of file
+# descriptors, the following condition should hold:
+# MaxThreads*MaxRecursion + (MaxQueue - MaxThreads) + 6< RLIMIT_NOFILE (usual
+# max is 1024).
 #
 # Default: 100
 #MaxQueue 200
@@ -239,8 +242,8 @@ TCPAddr 127.0.0.1
 # When enabled, if a heuristic scan (such as phishingScan) detects
 # a possible virus/phish it will stop scan immediately. Recommended, saves CPU
 # scan-time.
-# When disabled, virus/phish detected by heuristic scans will be reported only at
-# the end of a scan. If an archive contains both a heuristically detected
+# When disabled, virus/phish detected by heuristic scans will be reported only
+# at the end of a scan. If an archive contains both a heuristically detected
 # virus/phish, and a real malware, the real malware will be reported
 #
 # Keep this disabled if you intend to handle "*.Heuristics.*" viruses
@@ -261,11 +264,13 @@ TCPAddr 127.0.0.1
 # Default: no
 #AlertBrokenExecutables yes
 
-# Alert on encrypted archives _and_ documents with heuristic signature (encrypted .zip, .7zip, .rar, .pdf).
+# Alert on encrypted archives _and_ documents with heuristic signature
+# (encrypted .zip, .7zip, .rar, .pdf).
 # Default: no
 #AlertEncrypted yes
 
-# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip, .rar).
+# Alert on encrypted archives with heuristic signature (encrypted .zip, .7zip,
+# .rar).
 # Default: no
 #AlertEncryptedArchive yes
 
@@ -298,8 +303,8 @@ TCPAddr 127.0.0.1
 ##
 
 # PE stands for Portable Executable - it's an executable file format used
-# in all 32 and 64-bit versions of Windows operating systems. This option allows
-# ClamAV to perform a deeper analysis of executable files and it's also
+# in all 32 and 64-bit versions of Windows operating systems. This option
+# allows ClamAV to perform a deeper analysis of executable files and it's also
 # required for decompression of popular executable packers such as UPX, FSG,
 # and Petite. If you turn off this option, the original files will still be
 # scanned, but without additional processing.
@@ -371,7 +376,8 @@ TCPAddr 127.0.0.1
 #ScanMail yes
 
 # Scan RFC1341 messages split over many emails.
-# You will need to periodically clean up $TemporaryDirectory/clamav-partial directory.
+# You will need to periodically clean up $TemporaryDirectory/clamav-partial
+# directory.
 # WARNING: This option may open your system to a DoS attack.
 #	   Never use it on loaded servers.
 # Default: no
@@ -448,17 +454,17 @@ TCPAddr 127.0.0.1
 
 # This option sets the maximum amount of time to a scan may take.
 # In this version, this field only affects the scan time of ZIP archives.
-# Value of 0 disables the limit
+# Value of 0 disables the limit.
 # Note: disabling this limit or setting it too high may result allow scanning
-# of certain files to lock up the scanning process/threads resulting in a Denial
-# of Service.
+# of certain files to lock up the scanning process/threads resulting in a
+# Denial of Service.
 # Time is in milliseconds.
 # Default: 120000
 #MaxScanTime 300000
 
-# This option sets the maximum amount of data to be scanned for each input file.
-# Archives and other containers are recursively extracted and scanned up to this
-# value.
+# This option sets the maximum amount of data to be scanned for each input
+# file. Archives and other containers are recursively extracted and scanned
+# up to this value.
 # Value of 0 disables the limit
 # Note: disabling this limit or setting it too high may result in severe damage
 # to the system.
@@ -622,6 +628,3 @@ TCPAddr 127.0.0.1
 # Default: 5000
 # BytecodeTimeout 1000
 
-##
-## Statistics gathering and submitting
-##

--- a/win32/conf_examples/freshclam.conf.sample
+++ b/win32/conf_examples/freshclam.conf.sample
@@ -90,11 +90,11 @@ DatabaseMirror database.clamav.net
 # This option can be used multiple times. Support for:
 #   http(s)://, ftp(s)://, or file://
 # Default: no custom URLs
-#DatabaseCustomURL http://myserver.com/mysigs.ndb
-#DatabaseCustomURL https://myserver.com/mysigs.ndb
-#DatabaseCustomURL https://myserver.com:4567/whitelist.wdb
-#DatabaseCustomURL ftp://myserver.com/example.ldb
-#DatabaseCustomURL ftps://myserver.com:4567/example.ndb
+#DatabaseCustomURL http://myserver.example.com/mysigs.ndb
+#DatabaseCustomURL https://myserver.example.com/mysigs.ndb
+#DatabaseCustomURL https://myserver.example.com:4567/whitelist.wdb
+#DatabaseCustomURL ftp://myserver.example.com/example.ldb
+#DatabaseCustomURL ftps://myserver.example.com:4567/example.ndb
 #DatabaseCustomURL file://E:\Share\local.hdb
 
 # This option allows you to easily point freshclam to private mirrors.
@@ -107,15 +107,16 @@ DatabaseMirror database.clamav.net
 # and ScriptedUpdates. It can be used multiple times to provide
 # fall-back mirrors.
 # Default: disabled
-#PrivateMirror mirror1.mynetwork.com
-#PrivateMirror mirror2.mynetwork.com
+#PrivateMirror mirror1.example.com
+#PrivateMirror mirror2.example.com
 
 # Number of database checks per day.
 # Default: 12 (every two hours)
 #Checks 24
 
 # Proxy settings
-# The HTTPProxyServer may be prefixed with [scheme]:// to specify which kind of proxy is used.
+# The HTTPProxyServer may be prefixed with [scheme]:// to specify which kind
+# of proxy is used.
 #   http://     HTTP Proxy. Default when no scheme or proxy type is specified.
 #   https://    HTTPS Proxy. (Added in 7.52.0 for OpenSSL, GnuTLS and NSS)
 #   socks4://   SOCKS4 Proxy.
@@ -123,7 +124,7 @@ DatabaseMirror database.clamav.net
 #   socks5://   SOCKS5 Proxy.
 #   socks5h://  SOCKS5 Proxy. Proxy resolves URL hostname.
 # Default: disabled
-#HTTPProxyServer https://myproxy.com
+#HTTPProxyServer https://proxy.example.com
 #HTTPProxyPort 1234
 #HTTPProxyUsername myusername
 #HTTPProxyPassword mypass
@@ -179,17 +180,17 @@ DatabaseMirror database.clamav.net
 #TestDatabases yes
 
 # This option enables support for Google Safe Browsing. When activated for
-# the first time, freshclam will download a new database file (safebrowsing.cvd)
-# which will be automatically loaded by clamd and clamscan during the next
-# reload, provided that the heuristic phishing detection is turned on. This
-# database includes information about websites that may be phishing sites or
-# possible sources of malware. When using this option, it's mandatory to run
-# freshclam at least every 30 minutes.
+# the first time, freshclam will download a new database file
+# (safebrowsing.cvd) which will be automatically loaded by clamd and
+# clamscan during the next reload, provided that the heuristic phishing
+# detection is turned on. This database includes information about websites
+# that may be phishing sites or possible sources of malware. When using this
+# option, it's mandatory to run freshclam at least every 30 minutes.
 # Freshclam uses the ClamAV's mirror infrastructure to distribute the
 # database and its updates but all the contents are provided under Google's
-# terms of use. See https://transparencyreport.google.com/safe-browsing/
-# and https://www.clamav.net/documents/safebrowsing
-# for more information.
+# terms of use.
+# See https://transparencyreport.google.com/safe-browsing/overview
+# and https://www.clamav.net/documents/safebrowsing for more information.
 # Default: no
 #SafeBrowsing yes
 


### PR DESCRIPTION
Also use safe example.com addresses in examples.

Signed-off-by: Tuomo Soini <tis@foobar.fi>