### PR TITLE
clamscan: Add --multiscan option for parallel scan

### DIFF
--- a/clamscan/clamscan.c
+++ b/clamscan/clamscan.c
@@ -56,6 +56,7 @@ void help(void);
 struct s_info info;
 short recursion = 0, bell = 0;
 short printinfected = 0, printclean = 1;
+int multiscan_jobs;
 
 int main(int argc, char **argv)
 {
@@ -153,6 +154,8 @@ int main(int argc, char **argv)
         exit(2);
     }
 
+    multiscan_jobs = optget(opts, "multiscan")->numarg;
+
     memset(&info, 0, sizeof(struct s_info));
 
     gettimeofday(&t1, NULL);
@@ -218,6 +221,7 @@ void help(void)
     mprintf("    --infected            -i             Only print infected files\n");
     mprintf("    --suppress-ok-results -o             Skip printing OK files\n");
     mprintf("    --bell                               Sound bell on virus detection\n");
+    mprintf("    --multiscan=#n        -m             Number of parallel jobs to spawn (MULTISCAN mode)\n");
     mprintf("\n");
     mprintf("    --tempdir=DIRECTORY                  Create temporary files in DIRECTORY\n");
     mprintf("    --leave-temps[=yes/no(*)]            Do not remove temporary files\n");

--- a/clamscan/global.h
+++ b/clamscan/global.h
@@ -35,5 +35,6 @@ struct s_info {
 extern struct s_info info;
 extern short recursion, bell;
 extern short printinfected, printclean;
+extern int multiscan_jobs;
 
 #endif

--- a/docs/man/clamscan.1.in
+++ b/docs/man/clamscan.1.in
@@ -45,6 +45,9 @@ Skip printing OK files
 \fB\-\-bell\fR
 Sound bell on virus detection.
 .TP
+\fB\-m NUM, \-\-multiscan=NUM\fR
+Spawn NUM processes to scan files in parallel.
+.TP
 \fB\-\-tempdir=DIRECTORY\fR
 Create temporary files in DIRECTORY. Directory must be writable for the '@CLAMAVUSER@' user or unprivileged user running clamscan.
 .TP

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -153,6 +153,7 @@ const struct clam_option __clam_options[] = {
     {NULL, "no-trace-showsource", 's', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMBC, "Don't show source line during tracing", ""},
 
     {NULL, "archive-verbose", 'a', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMSCAN, "", ""},
+    {NULL, "multiscan", 'm', CLOPT_TYPE_NUMBER, MATCH_NUMBER, 0, NULL, 0, OPT_CLAMSCAN, "Number of parallel jobs to spawn", ""},
 
     /* cmdline only - deprecated */
     {NULL, "bytecode-trust-all", 't', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMSCAN | OPT_DEPRECATED, "", ""},


### PR DESCRIPTION
Adds -m/--multiscan=N option for clamscan to spawn N children to scan files in
parallel.

This is a rebase of PR #78 from Michal Marek (@michal42).

Signed-off-by: Enzo Matsumiya <ematsumiya@suse.de>