### PR TITLE
freshclam:Fix OnOutdatedExecute in foreground mode

### DIFF
--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -1781,7 +1781,7 @@ int main(int argc, char **argv)
             bPrivate ? 0 : optget(opts, "ScriptedUpdates")->enabled,
             bPrune,
             optget(opts, "OnUpdateExecute")->enabled ? optget(opts, "OnUpdateExecute")->strarg : NULL,
-            optget(opts, "OnOutdatedExecute")->enabled ? optget(opts, "OnUpdateExecute")->strarg : NULL,
+            optget(opts, "OnOutdatedExecute")->enabled ? optget(opts, "OnOutdatedExecute")->strarg : NULL,
             optget(opts, "daemon")->enabled,
             optget(opts, "NotifyClamd")->active ? optget(opts, "NotifyClamd")->strarg : NULL,
             &fc_context);


### PR DESCRIPTION
Fixes OnOutdatedExecute option in foreground mode. Code was using the OnUpdateExecute command instead.