### PR TITLE
freshclam: change default of ReceiveTimeout to 0

### DIFF
--- a/docs/man/freshclam.conf.5.in
+++ b/docs/man/freshclam.conf.5.in
@@ -199,9 +199,9 @@ Timeout in seconds when connecting to database server.
 Default: 10
 .TP
 \fBReceiveTimeout NUMBER\fR
-Timeout in seconds when reading from database server.
+Timeout in seconds when reading from database server. 0 means no timeout.
 .br
-Default: 60
+Default: 0
 .TP
 \fBSafeBrowsing BOOL\fR
 This option enables support for Google Safe Browsing. When activated for the first time, freshclam will download a new database file (safebrowsing.cvd) which will be automatically loaded by clamd and clamscan during the next reload, provided that the heuristic phishing detection is turned on. This database includes information about websites that may be phishing sites or possible sources of malware. When using this option, it's mandatory to run freshclam at least every 30 minutes. Freshclam uses the ClamAV's mirror infrastructure to distribute the database and its updates but all the contents are provided under Google's terms of use. See https://support.google.com/code/answer/70015 and https://www.clamav.net/documents/safebrowsing for more information.

--- a/etc/freshclam.conf.sample
+++ b/etc/freshclam.conf.sample
@@ -170,8 +170,8 @@ DatabaseMirror database.clamav.net
 #ConnectTimeout 60
 
 # Timeout in seconds when reading from database server.
-# Default: 60
-#ReceiveTimeout 300
+# Default: 0
+#ReceiveTimeout 1800
 
 # With this option enabled, freshclam will attempt to load new
 # databases into memory to make sure they are properly handled

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -496,7 +496,7 @@ const struct clam_option __clam_options[] = {
 
     {"ConnectTimeout", NULL, 0, CLOPT_TYPE_NUMBER, MATCH_NUMBER, 30, NULL, 0, OPT_FRESHCLAM, "Timeout in seconds when connecting to database server.", "30"},
 
-    {"ReceiveTimeout", NULL, 0, CLOPT_TYPE_NUMBER, MATCH_NUMBER, 60, NULL, 0, OPT_FRESHCLAM, "Timeout in seconds when reading from database server.", "60"},
+    {"ReceiveTimeout", NULL, 0, CLOPT_TYPE_NUMBER, MATCH_NUMBER, 0, NULL, 0, OPT_FRESHCLAM, "Timeout in seconds when reading from database server.", "0"},
 
     {"SafeBrowsing", NULL, 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_FRESHCLAM, "This option enables support for Google Safe Browsing. When activated for\nthe first time, freshclam will download a new database file (safebrowsing.cvd)\nwhich will be automatically loaded by clamd and clamscan during the next\nreload, provided that the heuristic phishing detection is turned on. This\ndatabase includes information about websites that may be phishing sites or\npossible sources of malware. When using this option, it's mandatory to run\nfreshclam at least every 30 minutes.\nFreshclam uses the ClamAV's mirror infrastructure to distribute the\ndatabase and its updates but all the contents are provided under Google's\nterms of use. See https://transparencyreport.google.com/safe-browsing/overview \n and https://www.clamav.net/documents/safebrowsing for more information.", "yes"},
 

--- a/win32/conf_examples/freshclam.conf.sample
+++ b/win32/conf_examples/freshclam.conf.sample
@@ -170,8 +170,8 @@ DatabaseMirror database.clamav.net
 #ConnectTimeout 60
 
 # Timeout in seconds when reading from database server.
-# Default: 60
-#ReceiveTimeout 300
+# Default: 0
+#ReceiveTimeout 1800
 
 # With this option enabled, freshclam will attempt to load new
 # databases into memory to make sure they are properly handled


### PR DESCRIPTION
This fixes issues in cvd download when network speed is slow.
Setting is passed to libcurl CURLOPT_TIMEOUT. Original default of 60s
was not enough if network speed is limited. Curl handles this as
total time for http(s) transfer.

https://curl.haxx.se/libcurl/c/CURLOPT_TIMEOUT.html

Also change commented out setting of ReceiveTimeout on example configs
to somewhat sensible value (1800s).

Signed-off-by: Tuomo Soini <tis@foobar.fi>