### PR TITLE
Update clamonacc.c

### DIFF
--- a/clamonacc/clamonacc.c
+++ b/clamonacc/clamonacc.c
@@ -64,7 +64,7 @@ static void onas_clamonacc_exit(int sig)
 {
     logg("*Clamonacc: onas_clamonacc_exit(), signal %d\n", sig);
     if (sig == 11) {
-        logg("!Clamonacc: clamonacc has experienced a fatal error, if you continue to see this error, please run clamonacc with --debug and report the issue and crash report to the developpers\n");
+        logg("!Clamonacc: clamonacc has experienced a fatal error, if you continue to see this error, please run clamonacc with --verbose and report the issue and crash report to the developpers\n");
     }
 
     if (g_ctx) {


### PR DESCRIPTION
The clamonacc command doesn't present a `--debug` flag, but according to your blog https://blog.clamav.net/2019/09/understanding-and-transitioning-to.html the correct flag should be `--verbose`:
"[...]This is akin to clamd’s or clamscan’s --debug option, but isn’t quite so noisy as either of those. By default, clamonacc does not print any output after daemonizing, so you will have to pair this option with --log or --foreground to use it.[...]"