### PR TITLE
freshclam: Fix execute() function on Windows in daemon mode

### DIFF
--- a/freshclam/execute.c
+++ b/freshclam/execute.c
@@ -53,7 +53,7 @@ void execute(const char *type, const char *text, int bDaemonized)
     }
 
 #ifdef _WIN32
-    if (spawnlp(_P_NOWAIT, text, text, NULL) == -1) {
+    if (system(text) == -1) {
         logg("^%s: couldn't execute \"%s\".\n", type, text);
         return;
     }


### PR DESCRIPTION
Currently, freshclam's "OnUpdateExecute", etc., features will fail when running on Windows in daemon mode if the supplied command contains any arguments. This is because of incorrect usage of spawnlp() in the execute() function. This patch simply replaces it with a call to system(), which also makes it consistent with non-daemon mode on Windows and both modes on other platforms.