### PR TITLE
multithreaded database reloading

### DIFF
--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -552,7 +552,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        if ((ret = statinidir_th(dbdir))) {
+        if ((ret = statinidir(dbdir))) {
             logg("!%s\n", cl_strerror(ret));
             ret = 1;
             break;
@@ -744,7 +744,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        ret = recvloop_th(lsockets, nlsockets, engine, dboptions, opts);
+        ret = recvloop(lsockets, nlsockets, engine, dboptions, opts);
 
     } while (0);
 

--- a/clamd/server.h
+++ b/clamd/server.h
@@ -37,8 +37,8 @@ struct thrarg {
     const struct cl_engine *engine;
 };
 
-int recvloop_th(int *socketds, unsigned nsockets, struct cl_engine *engine, unsigned int dboptions, const struct optstruct *opts);
-int statinidir_th(const char *dirname);
+int recvloop(int *socketds, unsigned nsockets, struct cl_engine *engine, unsigned int dboptions, const struct optstruct *opts);
+int statinidir(const char *dirname);
 void sighandler(int sig);
 void sighandler_th(int sig);
 void sigsegv(int sig);

--- a/unit_tests/valgrind.supp
+++ b/unit_tests/valgrind.supp
@@ -196,7 +196,7 @@
    obj:/usr/local/lib/valgrind/memcheck-x86-freebsd
    fun:send
    fun:fds_poll_recv
-   fun:recvloop_th
+   fun:recvloop
    obj:/lib/libthr.so.3
 }
 {
@@ -207,7 +207,7 @@
    obj:/usr/local/lib/valgrind/memcheck-x86-freebsd
    fun:poll
    fun:fds_poll_recv
-   fun:recvloop_th
+   fun:recvloop
    ...
 }
 {


### PR DESCRIPTION
> What it does is offloading the DB load to a separate thread and only replace the current engine instance afterwards.
>
> That means that while reload is pending:
> - existing scan requests use the old db (this is unchanged)
> - new scan requests are honored instead of blocked and they also use the old db (this is new)
>
> After the reload is complete:
> - existing scan requests use the old db (this is unchanged)
> - new scan requests use the new db (this is unchanged)
>
> The existing engine is refcounted so it'll be eventually freed when no longer in use.
>
> Reload requests while reload is pending are silently ignored (i.e. I never fork more than a single reload thread). I think this is perfectly acceptable as the reload time is a few seconds (10-60) while the db update frequency is several hours. If someone has stupidly short release cycles they can still rely on SelfCheck.

Closes: https://bugzilla.clamav.net/show_bug.cgi?id=10979

@jendis