### PR TITLE
libfreshclam: Avoid division-by-zero + further optimization in progress function

### DIFF
--- a/libfreshclam/libfreshclam_internal.c
+++ b/libfreshclam/libfreshclam_internal.c
@@ -215,7 +215,6 @@ static int xferinfo(void *prog,
     curl_easy_getinfo(curl, TIMEOPT, &curtime);
 
     xferProg->lastRunTime = curtime;
-    remtime               = (curtime / fractiondownloaded) - curtime;
 
 #ifndef _WIN32
     fprintf(stdout, "\e[?7l");
@@ -226,6 +225,7 @@ static int xferinfo(void *prog,
         printTime(curtime / 1000000.0);
         fprintf(stdout, "               ");
     } else {
+        remtime = (curtime / fractiondownloaded) - curtime;
         fprintf(stdout, "Time: ");
         printTime(curtime / 1000000.0);
         fprintf(stdout, ", ETA: ");
@@ -238,6 +238,7 @@ static int xferinfo(void *prog,
         printTime(curtime);
         fprintf(stdout, "               ");
     } else {
+        remtime = (curtime / fractiondownloaded) - curtime;
         fprintf(stdout, "Time: ");
         printTime(curtime);
         fprintf(stdout, ", ETA: ");
@@ -262,15 +263,9 @@ static int xferinfo(void *prog,
 
     fprintf(stdout, "] ");
 
-    if (TotalToUpload > 0.0) {
-        printBytes(NowUploaded, 1);
-        fprintf(stdout, "/");
-        printBytes(TotalToUpload, 0);
-    } else if (TotalToDownload > 0.0) {
-        printBytes(NowDownloaded, 1);
-        fprintf(stdout, "/");
-        printBytes(TotalToDownload, 0);
-    }
+    printBytes(NowDownloaded, 1);
+    fprintf(stdout, "/");
+    printBytes(TotalToDownload, 0);
 
     if (NowDownloaded < TotalToDownload) {
         fprintf(stdout, "\r");


### PR DESCRIPTION
I didn't notice it in time to include it in my last pull request, but it looks like division by zero could occur where the value of `remtime` is calculated and assigned in `xferinfo()`. I haven't run into any divide-by-zero errors myself, but considering that the function already handles `fractiondownloaded` being less than or equal to 0.0 when printing the time values, I'm assuming it's possible. This patch simply moves the calculation/assignment so it will only be done if `fractiondownloaded` is greater than 0.0 (`remtime` is otherwise unused anyway).

While I was at it, I also removed the handling of `NowUploaded`/`TotalToUpload` and the `if` statements altogether where it calls `printBytes()`. The rest of the function is not coded to handle uploads, and the function already returns early if `TotalToDownload` is less than or equal to 0.0, so this code was simply reducing its efficiency.