### PR TITLE
clamdtop: Fix header label alignment; tweaks to better fit 80-column windows

### DIFF
--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -505,12 +505,15 @@ static void print_con_info(conn_t *conn, const char *fmt, ...)
     va_list ap;
     va_start(ap, fmt);
     if (stats_head_window) {
-        char *buf = malloc(maxx);
+        char *buf = malloc(maxx + 1);
+	char *nl = NULL;
         OOM_CHECK(buf);
-        memset(buf, ' ', maxx);
-        vsnprintf(buf, maxx - 1, fmt, ap);
+        memset(buf, ' ', maxx + 1);
+        vsnprintf(buf, maxx + 1, fmt, ap);
+	if ((nl = strchr(buf, '\n')) != NULL)
+            *nl = ' ';
         buf[strlen(buf)] = ' ';
-        buf[maxx - 1]    = '\0';
+        buf[maxx]    = '\0';
         wattron(stats_head_window, ERROR_ATTR);
         mvwprintw(stats_head_window, conn->line, 0, "%s", buf);
         wattroff(stats_head_window, ERROR_ATTR);

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -130,6 +130,7 @@ static void exit_program(enum exit_reason reason, const char *func, unsigned lin
     } while (0)
 
 static struct global_stats global;
+static SCREEN *curses_scr  = NULL;
 static int curses_inited   = 0;
 static int maxystats       = 0;
 static int detail_selected = -1;
@@ -290,7 +291,12 @@ static void init_ncurses(int num_clamd, int use_default)
 {
     int default_bg = use_default ? DEFAULT_COLOR : COLOR_BLACK;
     int default_fg = use_default ? DEFAULT_COLOR : COLOR_WHITE;
-    initscr();
+
+    /* newterm() allows us to free curses-allocated memory with delscreen() */
+    if (!(curses_scr = newterm(NULL, stdout, stdin))) {
+        fprintf(stderr, "Failed to initialize curses\n");
+        exit(EXIT_FAILURE);
+    }
     curses_inited = 1;
 
     start_color();
@@ -427,6 +433,7 @@ static void cleanup(void)
         }
         rm_windows();
         endwin();
+        delscreen(curses_scr);
     }
     curses_inited = 0;
     for (i = 0; i < global.num_clamd; i++) {

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -895,7 +895,7 @@ static void output_queue(size_t line, ssize_t max)
             if (filtered_tasks[i].line + 15 > cmde)
                 cmd[cmde - filtered_tasks[i].line] = '\0';
             if (filstart) {
-                size_t oldline = (line += i);
+                size_t oldline = line;
                 char *nl = strrchr(++filstart, '\n');
                 if (nl != NULL)
                     *nl = '\0';
@@ -908,6 +908,7 @@ static void output_queue(size_t line, ssize_t max)
                 line = getcury(stats_window);
                 if (line > oldline)
                     max -= line - oldline;
+                line++;
             }
         }
     }

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -506,11 +506,11 @@ static void print_con_info(conn_t *conn, const char *fmt, ...)
     va_start(ap, fmt);
     if (stats_head_window) {
         char *buf = malloc(maxx + 1);
-	char *nl = NULL;
+        char *nl  = NULL;
         OOM_CHECK(buf);
         memset(buf, ' ', maxx + 1);
         vsnprintf(buf, maxx + 1, fmt, ap);
-	if ((nl = strchr(buf, '\n')) != NULL)
+        if ((nl = strchr(buf, '\n')) != NULL)
             *nl = ' ';
         buf[strlen(buf)] = ' ';
         buf[maxx]    = '\0';

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -513,7 +513,7 @@ static void print_con_info(conn_t *conn, const char *fmt, ...)
         if ((nl = strchr(buf, '\n')) != NULL)
             *nl = ' ';
         buf[strlen(buf)] = ' ';
-        buf[maxx]    = '\0';
+        buf[maxx]        = '\0';
         wattron(stats_head_window, ERROR_ATTR);
         mvwprintw(stats_head_window, conn->line, 0, "%s", buf);
         wattroff(stats_head_window, ERROR_ATTR);

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -637,9 +637,9 @@ static int make_connection_real(const char *soname, conn_t *conn)
 {
     int s = -1;
     struct timeval tv;
-    char *port       = NULL;
-    char *pt         = NULL;
-    char *host       = pt;
+    char *port = NULL;
+    char *pt   = NULL;
+    char *host = pt;
     struct addrinfo hints, *res = NULL, *p;
     int err;
     int ret = 0;

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -1072,7 +1072,7 @@ static int output_stats(struct stats *stats, unsigned idx)
     i   = 0;
     if (sel && !stats->stats_unsupp) {
         memset(line, ' ', maxx + 1);
-        snprintf(line, maxx - 1, "Details for Clamd version: %s", stats->version);
+        snprintf(line, maxx + 1, "Details for Clamd version: %s", stats->version);
         line[maxx]         = '\0';
         line[strlen(line)] = ' ';
         wattron(win, COLOR_PAIR(queue_header_color));

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -196,7 +196,7 @@ static char *clamd_header = NULL;
  * LIVETHR - sum of live threads
  * IDLETHR - sum of idle threads
  */
-#define SUMHEAD "NO CONNTIME LIV IDL QUEUE  MAXQ   MEM HOST           ENGINE DBVER DBTIME"
+#define SUMHEAD "NO CONNTIME LIV IDL QUEUE  MAXQ   MEM HOST           ENGINE  DBVER DBTIME"
 
 static void resize(void)
 {
@@ -1050,13 +1050,13 @@ static int output_stats(struct stats *stats, unsigned idx)
 
     memset(line, ' ', maxx + 1);
     if (!stats->stats_unsupp) {
-        snprintf(line, maxx - 1, "%2u %02u:%02u:%02u %3u %3u %5u %5u %5s %-14s %-6s %5s %s", idx + 1, stats->conn_hr, stats->conn_min, stats->conn_sec,
+        snprintf(line, maxx + 1, "%2u %02u:%02u:%02u %3u %3u %5u %5u %5s %-14s %-6s %5s %s", idx + 1, stats->conn_hr, stats->conn_min, stats->conn_sec,
                  stats->live, stats->idle,
                  stats->current_q, stats->biggest_queue,
                  mem,
                  stats->remote, stats->engine_version, stats->db_version, timbuf);
     } else {
-        snprintf(line, maxx - 1, "%2u %02u:%02u:%02u N/A N/A   N/A   N/A   N/A %-14s %-6s %5s %s", idx + 1, stats->conn_hr, stats->conn_min, stats->conn_sec,
+        snprintf(line, maxx + 1, "%2u %02u:%02u:%02u N/A N/A   N/A   N/A   N/A %-14s %-6s %5s %s", idx + 1, stats->conn_hr, stats->conn_min, stats->conn_sec,
                  stats->remote, stats->engine_version, stats->db_version, timbuf);
     }
     line[maxx]         = '\0';
@@ -1079,7 +1079,7 @@ static int output_stats(struct stats *stats, unsigned idx)
         mvwprintw(win, i++, 0, "%s", line);
         wattroff(win, COLOR_PAIR(queue_header_color));
         mvwprintw(win, i++, 0, "Primary threads: ");
-        snprintf(buf, sizeof(buf), "live %3u idle %3u max %3u", stats->prim_live, stats->prim_idle, stats->prim_max);
+        snprintf(buf, sizeof(buf), "live%3u idle%3u max%3u", stats->prim_live, stats->prim_idle, stats->prim_max);
         print_colored(win, buf);
         show_bar(win, i++, stats->prim_live, stats->prim_idle, stats->prim_max, 0);
         /*		mvwprintw(win, i++, 0, "Multiscan pool : ");

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -132,7 +132,7 @@ static void exit_program(enum exit_reason reason, const char *func, unsigned lin
     } while (0)
 
 static struct global_stats global;
-static int curses_inited   = 1;
+static int curses_inited   = 0;
 static int maxystats       = 0;
 static int detail_selected = -1;
 
@@ -720,6 +720,15 @@ end:
     tv.tv_sec  = 30;
     tv.tv_usec = 0;
     setsockopt(conn->sd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    if (conn->remote != soname) {
+        /* when we reconnect, they are the same */
+        if (NULL != conn->remote) {
+            free(conn->remote);
+            conn->remote = NULL;
+        }
+        conn->remote = make_ip(host, (port != NULL) ? port : "3310");
+    }
 
 done:
     if (NULL != res) {

--- a/clamdtop/clamdtop.c
+++ b/clamdtop/clamdtop.c
@@ -185,8 +185,8 @@ static unsigned maxy = 0, maxx = 0;
 static char *queue_header = NULL;
 static char *clamd_header = NULL;
 
-#define CMDHEAD " COMMAND        QUEUEDSINCE   FILE"
-#define CMDHEAD2 " # COMMAND     QUEUEDSINCE   FILE"
+#define CMDHEAD  " COMMAND       QUEUEDSINCE    FILE"
+#define CMDHEAD2 " # COMMAND     QUEUEDSINCE    FILE"
 
 /*
  * CLAMD - which local/remote clamd this is


### PR DESCRIPTION
Currently, the `DBVER` and `DBTIME` header labels are no longer correctly aligned, because of current (as of 0.100.x) ClamAV version numbers being wider. This patch fixes this.

This patch also tweaks the printing of primary thread counts and header values so they fit in 80-column windows (as best as possible; the `h` suffix of the `DBTIME` hour value still doesn't fit, but at least the value does). Previously, an 83-column window was required for the information to fit. (As a side effect, the alignment of the thread counts relative to the bar underneath looks cleaner.)