### PR TITLE
For review: clamd multi-threaded reload 0.103

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,24 @@ ClamAV 0.103.0 includes the following improvements and changes.
 
 ### Major changes
 
+- Clamd can now reload the signature database without blocking scanning.
+  This multi-threaded database reload improvement was made possible thanks to
+  a community effort.
+
+  Non-blocking database reloads are now the default behavior. Some systems that
+  are more contrained on RAM may need to disable non-blocking reloads as it will
+  temporarily consume 2x as much memory. For this purpose we have added a new
+  clamd config option `ConcurrentDatabaseReload` which may be set to `no`.
+
+  Special thanks to the following for making this feature a reality:
+  - Alberto Wu
+  - Alexander Sulfrian
+  - Arjen de Korte
+  - David Heidelberg
+  - Ged Haywood
+
+  Thank you all for your patience waiting for this feature.
+
 ### Notable changes
 
 - The DLP module has been enhanced with additional credit card ranges and a new

--- a/clamd/clamd.c
+++ b/clamd/clamd.c
@@ -552,7 +552,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        if ((ret = statinidir_th(dbdir))) {
+        if ((ret = statinidir(dbdir))) {
             logg("!%s\n", cl_strerror(ret));
             ret = 1;
             break;
@@ -744,7 +744,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        ret = recvloop_th(lsockets, nlsockets, engine, dboptions, opts);
+        ret = recvloop(lsockets, nlsockets, engine, dboptions, opts);
 
     } while (0);
 

--- a/clamd/server.h
+++ b/clamd/server.h
@@ -37,8 +37,8 @@ struct thrarg {
     const struct cl_engine *engine;
 };
 
-int recvloop_th(int *socketds, unsigned nsockets, struct cl_engine *engine, unsigned int dboptions, const struct optstruct *opts);
-int statinidir_th(const char *dirname);
+int recvloop(int *socketds, unsigned nsockets, struct cl_engine *engine, unsigned int dboptions, const struct optstruct *opts);
+int statinidir(const char *dirname);
 void sighandler(int sig);
 void sighandler_th(int sig);
 void sigsegv(int sig);

--- a/clamd/thrmgr.h
+++ b/clamd/thrmgr.h
@@ -99,6 +99,7 @@ enum thrmgr_exit {
 
 threadpool_t *thrmgr_new(int max_threads, int idle_timeout, int max_queue, void (*handler)(void *));
 void thrmgr_destroy(threadpool_t *threadpool);
+void thrmgr_wait_for_threads(threadpool_t *threadpool);
 int thrmgr_dispatch(threadpool_t *threadpool, void *user_data);
 int thrmgr_group_dispatch(threadpool_t *threadpool, jobgroup_t *group, void *user_data, int bulk);
 void thrmgr_group_waitforall(jobgroup_t *group, unsigned *ok, unsigned *error, unsigned *total);

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -234,6 +234,11 @@ should perform a database check.
 .br
 Default: 600
 .TP
+\fBConcurrentDatabaseReload BOOL\fR
+Enable non-blocking (multi-threaded/concurrent) database reloads. This feature will temporarily load a second scanning engine while scanning continues using the first engine. Once loaded, the new engine takes over. The old engine is removed as soon as all scans using the old engine have completed. This feature requires more RAM, so this option is provided in case users are willing to block scans during reload in exchange for lower RAM requirements.
+.br
+Default: yes
+.TP
 \fBVirusEvent COMMAND\fR
 Execute a command when a virus is found. In the command string %v will be
 replaced with the virus name. Additionally, two environment variables will
@@ -398,7 +403,7 @@ Default: 3
 .TP
 \fBStructuredCCOnly BOOL\fR
 With this option enabled the DLP module will search for valid Credit Card\nnumbers only. Debit and Private Label cards will not be searched.
-.br 
+.br
 Default: No
 .TP
 \fBStructuredMinSSNCount NUMBER\fR

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -196,6 +196,15 @@ Example
 # Default: 600 (10 min)
 #SelfCheck 600
 
+# Enable non-blocking (multi-threaded/concurrent) database reloads. This feature
+# will temporarily load a second scanning engine while scanning continues using
+# the first engine. Once loaded, the new engine takes over. The old engine is
+# removed as soon as all scans using the old engine have completed. This feature
+# requires more RAM, so this option is provided in case users are willing to
+# block scans during reload in exchange for lower RAM requirements.
+# Default: yes
+#ConcurrentDatabaseReload no
+
 # Execute a command when virus is found. In the command string %v will
 # be replaced with the virus name.
 # Default: no

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -271,6 +271,8 @@ const struct clam_option __clam_options[] = {
 
     {"SelfCheck", NULL, 0, CLOPT_TYPE_NUMBER, MATCH_NUMBER, 600, NULL, 0, OPT_CLAMD, "This option specifies the time intervals (in seconds) in which clamd\nshould perform a database check.", "600"},
 
+    {"ConcurrentDatabaseReload", NULL, 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 1, NULL, 0, OPT_CLAMD, "Enable non-blocking (multi-threaded/concurrent) database reloads. This feature \nwill temporarily load a second scanning engine while scanning continues using \nthe first engine. Once loaded, the new engine takes over. The old engine is \nremoved as soon as all scans using the old engine have completed. This feature \nrequires more RAM, so this option is provided in case users are willing to \nblock scans during reload in exchange for lower RAM requirements.", "yes"},
+
     {"DisableCache", "disable-cache", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_CLAMSCAN, "This option allows you to disable clamd's caching feature.", "no"},
 
     {"VirusEvent", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_CLAMD, "Execute a command when a virus is found. In the command string %v will be\nreplaced with the virus name. Additionally, two environment variables will\nbe defined: $CLAM_VIRUSEVENT_FILENAME and $CLAM_VIRUSEVENT_VIRUSNAME.", "/usr/bin/mailx -s \"ClamAV VIRUS ALERT: %v\" alert < /dev/null"},

--- a/unit_tests/check_common.sh
+++ b/unit_tests/check_common.sh
@@ -312,6 +312,7 @@ run_reload_test()
 	grep "ClamAV-RELOAD-TestFile" clamdscan.log >/dev/null 2>/dev/null && die "RELOAD test(1) failed!"
 	echo "ClamAV-RELOAD-TestFile:0:0:436c616d41562d52454c4f41442d54657374" >test-db/new.ndb
 	$CLAMDSCAN --reload --config-file=test-clamd.conf || die "clamdscan says reload failed!"
+	sleep 1
 	run_clamdscan reload-testfile
 	failed=0
 	grep "ClamAV-RELOAD-TestFile" clamdscan.log >/dev/null 2>/dev/null || die "RELOAD test failed! (after reload)"

--- a/unit_tests/valgrind.supp
+++ b/unit_tests/valgrind.supp
@@ -196,7 +196,7 @@
    obj:/usr/local/lib/valgrind/memcheck-x86-freebsd
    fun:send
    fun:fds_poll_recv
-   fun:recvloop_th
+   fun:recvloop
    obj:/lib/libthr.so.3
 }
 {
@@ -207,7 +207,7 @@
    obj:/usr/local/lib/valgrind/memcheck-x86-freebsd
    fun:poll
    fun:fds_poll_recv
-   fun:recvloop_th
+   fun:recvloop
    ...
 }
 {

--- a/win32/conf_examples/clamd.conf.sample
+++ b/win32/conf_examples/clamd.conf.sample
@@ -172,6 +172,15 @@ TCPAddr 127.0.0.1
 # Default: 600 (10 min)
 #SelfCheck 600
 
+# Enable non-blocking (multi-threaded/concurrent) database reloads. This feature
+# will temporarily load a second scanning engine while scanning continues using
+# the first engine. Once loaded, the new engine takes over. The old engine is
+# removed as soon as all scans using the old engine have completed. This feature
+# requires more RAM, so this option is provided in case users are willing to
+# block scans during reload in exchange for lower RAM requirements.
+# Default: yes
+#ConcurrentDatabaseReload no
+
 # Execute a command when virus is found. In the command string %v will
 # be replaced with the virus name.
 # Default: no


### PR DESCRIPTION
I'm providing this multi-threaded reload PR for review, as per the request in https://github.com/Cisco-Talos/clamav-devel/pull/123

Associated bugzilla ticket: https://bugzilla.clamav.net/show_bug.cgi?id=10979

In addition to the patch crafted by Alberto Wu that provides the default non-blocking clamd database reload improvement, this PR includes an option to block on the reload to provide the behavior like you see in 0.102 and prior versions.  This option probably won't be very popular, but may be needed on some machines to reduce RAM usage. 

To try the blocking-reload, set `ConcurrentDatabaseReload no` in your clamd.conf config file.
