### PR TITLE
Fix unzip

### DIFF
--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -1252,7 +1252,7 @@ cl_error_t cli_unzip(cli_ctx *ctx)
     if (virus_found == 1) {
         ret = CL_VIRUS;
     }
-    if (num_files_unzipped <= (file_count / 4)) { /* FIXME: make up a sane ratio or remove the whole logic */
+    if (0 < num_files_unzipped && num_files_unzipped <= (file_count / 4)) { /* FIXME: make up a sane ratio or remove the whole logic */    
         file_count = 0;
         while ((ret == CL_CLEAN) &&
                (lhoff < fsize) &&

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -614,7 +614,7 @@ static unsigned int parse_local_file_header(
     char name[256];
     char *original_filename = NULL;
     uint32_t csize, usize;
-    int virus_found = 0;
+    int virus_found                          = 0;
     unsigned int size_of_fileheader_and_data = 0;
 
     if (!(local_header = fmap_need_off(map, loff, SIZEOF_LOCAL_HEADER))) {
@@ -957,7 +957,7 @@ cl_error_t index_the_central_directory(
     struct zip_record *curr_record   = NULL;
     struct zip_record *prev_record   = NULL;
     uint32_t num_overlapping_files   = 0;
-    int virus_found = 0;
+    int virus_found                  = 0;
 
     if (NULL == catalogue || NULL == num_records) {
         cli_errmsg("index_the_central_directory: Invalid NULL arguments\n");
@@ -1035,7 +1035,7 @@ cl_error_t index_the_central_directory(
 
     if (ret == CL_VIRUS) {
         if (SCAN_ALLMATCHES)
-	    virus_found = 1;
+            virus_found = 1;
         else {
             status = CL_VIRUS;
             goto done;
@@ -1168,10 +1168,10 @@ cl_error_t cli_unzip(cli_ctx *ctx)
             &zip_catalogue,
             &records_count);
         if (CL_SUCCESS != ret) {
-	    if (CL_VIRUS == ret && SCAN_ALLMATCHES)
-               virus_found = 1;
-	    else {
-	        goto done;
+            if (CL_VIRUS == ret && SCAN_ALLMATCHES)
+                virus_found = 1;
+            else {
+                goto done;
             }
         }
 

--- a/libclamav/unzip.c
+++ b/libclamav/unzip.c
@@ -1252,7 +1252,7 @@ cl_error_t cli_unzip(cli_ctx *ctx)
     if (virus_found == 1) {
         ret = CL_VIRUS;
     }
-    if (0 < num_files_unzipped && num_files_unzipped <= (file_count / 4)) { /* FIXME: make up a sane ratio or remove the whole logic */    
+    if (0 < num_files_unzipped && num_files_unzipped <= (file_count / 4)) { /* FIXME: make up a sane ratio or remove the whole logic */
         file_count = 0;
         while ((ret == CL_CLEAN) &&
                (lhoff < fsize) &&


### PR DESCRIPTION
This fixes false negative result for e.g. *.cbd rules when _HeuristicScanPrecedence_ or _--heuristic-scan-precedence_ options set to _yes_.
Actually the [113dbc5](https://github.com/Cisco-Talos/clamav-devel/commit/113dbc53a7094d0334f7c3c48d704ce123ac655a) would even create the false positive again without changes in the previous commit [d13ffd9](https://github.com/Cisco-Talos/clamav-devel/commit/d13ffd9632a7d54032995928662f95adb7c70975).
So in another words, the rules *.cbd have been working when  _HeuristicScanPrecedence_ or _--heuristic-scan-precedence_ options set to no because of the original line in [d13ffd9](https://github.com/Cisco-Talos/clamav-devel/commit/d13ffd9632a7d54032995928662f95adb7c70975).
This is broken since release clamav-0.101.5.
