### PR TITLE
Upstream docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+build/
+configure.ac
+COPYING*
+examples/
+INSTALL*
+Jenkinsfile
+Makefile.am
+m4/
+README.md
+win32/

--- a/.github/workflows/docker_virusdb-update.yml
+++ b/.github/workflows/docker_virusdb-update.yml
@@ -1,0 +1,16 @@
+name: Docker image virus database update
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  Release_virusdb_update:
+    runs-on: alpine-latest
+
+    steps:
+      - name: Release update virus database and push image
+        env:
+          CLAMAV_DOCKER_PASSWD: "${{ secrets.CLAMAV_DOCKER_PASSWD }}"
+          CLAMAV_DOCKER_USER: "${{ secrets.CLAMAV_DOCKER_USER }}"
+        run: "dockerfiles/release_db_update.sh"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,12 +195,18 @@ if(ENABLE_TESTS)
     find_package(Python3 REQUIRED)
 
     execute_process(
-        COMMAND ${Python3_EXECUTABLE} -m pip show pytest
-        RESULT_VARIABLE EXIT_CODE
+        COMMAND pytest --version
+        RESULT_VARIABLE PYTEST_EXIT_CODE
         ERROR_QUIET OUTPUT_QUIET
     )
 
-    if (NOT ${EXIT_CODE} EQUAL 0)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -m pip show pytest
+        RESULT_VARIABLE PIP_EXIT_CODE
+        ERROR_QUIET OUTPUT_QUIET
+    )
+
+    if ((NOT ${PYTEST_EXIT_CODE} EQUAL 0) AND (NOT ${PIP_EXIT_CODE} EQUAL 0))
         message("Python3 package 'pytest' is not installed.")
         message("Failed unit tests will be easier to read if you install pytest.")
         message("Eg:  python3 -m pip install --user pytest")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,8 +679,18 @@ set(libdir      "${CMAKE_INSTALL_FULL_LIBDIR}")
 set(includedir  "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 set(VERSION     "${PACKAGE_VERSION}")
 
-# DBDIR for systemd service.in files
-set(DBDIR       "${CMAKE_INSTALL_PREFIX}/${DATABASE_DIRECTORY}")
+# Absolute path of database directory
+if(IS_ABSOLUTE ${DATABASE_DIRECTORY})
+    set(DATADIR "${DATABASE_DIRECTORY}")
+else()
+    set(DATADIR "${CMAKE_INSTALL_PREFIX}/${DATABASE_DIRECTORY}")
+endif()
+# Absolute path of the applications' config directory
+if(IS_ABSOLUTE ${APP_CONFIG_DIRECTORY})
+    set(CONFDIR "${APP_CONFIG_DIRECTORY}")
+else()
+    set(CONFDIR "${CMAKE_INSTALL_PREFIX}/${APP_CONFIG_DIRECTORY}")
+endif()
 
 if(ENABLE_DEBUG)
     set(CL_DEBUG 1)
@@ -852,6 +862,8 @@ ${c}    Package Version:        ${e}${PACKAGE_STRING}
 ${c}    libclamav version:      ${e}${LIBCLAMAV_CURRENT}:${LIBCLAMAV_REVISION}:${LIBCLAMAV_AGE}
 ${c}    libfreshclam version:   ${e}${LIBFRESHCLAM_CURRENT}:${LIBFRESHCLAM_REVISION}:${LIBFRESHCLAM_AGE}
 ${c}    Install prefix:         ${e}${CMAKE_INSTALL_PREFIX}
+${c}    Install database dir:   ${e}${DATADIR}
+${c}    Install config dir:     ${e}${CONFDIR}
 ${c}    Host system:            ${e}${CMAKE_HOST_SYSTEM}
 ${c}    Target system:          ${e}${CMAKE_SYSTEM}
 ${c}    Compiler:               ${e}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2020 Olliver Schinagl <oliver@schinagl.nl>
+# Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+# hadolint ignore=DL3007  latest is the latest stable for alpine
+FROM registry.hub.docker.com/library/alpine:latest AS builder
+
+LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
+
+EXPOSE 3310
+EXPOSE 7357
+
+HEALTHCHECK CMD "clamdcheck.sh"
+
+WORKDIR /src
+
+COPY . /src/
+
+# hadolint ignore=DL3008  We want the latest stable versions
+RUN apk add --no-cache \
+        bsd-compat-headers \
+        bzip2-dev \
+        check-dev \
+        cmake \
+        curl-dev \
+        file \
+        fts-dev \
+        g++ \
+        git \
+        json-c-dev \
+        libmilter-dev \
+        libtool \
+        libxml2-dev \
+        linux-headers \
+        make \
+        ncurses-dev \
+        openssl-dev \
+        pcre2-dev \
+        py3-pytest \
+        zlib-dev \
+    && \
+    addgroup -S "clamav" && \
+    adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -S "clamav" && \
+    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
+    mkdir -p "./build" && \
+    cd "./build" && \
+    cmake .. \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DCMAKE_INSTALL_PREFIX="/usr" \
+          -DCMAKE_INSTALL_LIBDIR="/usr/lib" \
+          -DAPP_CONFIG_DIRECTORY="/etc/clamav" \
+          -DDATABASE_DIRECTORY="/var/lib/clamav" \
+          -DENABLE_CLAMONACC=OFF \
+          -DENABLE_EXAMPLES=OFF \
+          -DENABLE_JSON_SHARED=ON \
+          -DENABLE_MAN_PAGES=OFF \
+          -DENABLE_MILTER=ON \
+          -DENABLE_STATIC_LIB=OFF && \
+    make DESTDIR="/clamav" -j$(($(nproc) - 1)) install && \
+    rm -r \
+       "/clamav/usr/include" \
+       "/clamav/usr/lib/pkgconfig/" \
+    && \
+    sed -e "s|^\(Example\)|\# \1|" \
+        -e "s|.*\(PidFile\) .*|\1 /run/lock/clamd.pid|" \
+        -e "s|.*\(LocalSocket\) .*|\1 /run/clamav/clamd.sock|" \
+        -e "s|.*\(TCPSocket\) .*|\1 3310|" \
+        -e "s|.*\(TCPAddr\) .*|\1 0.0.0.0|" \
+        -e "s|.*\(User\) .*|\1 clamav|" \
+        -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/clamd.log|" \
+        -e "s|^\#\(LogTime\).*|\1 yes|" \
+        "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
+    sed -e "s|^\(Example\)|\# \1|" \
+        -e "s|.*\(PidFile\) .*|\1 /run/lock/freshclam.pid|" \
+        -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
+        -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
+        -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
+        -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
+        "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
+    sed -e "s|^\(Example\)|\# \1|" \
+        -e "s|.*\(PidFile\) .*|\1 /run/lock/clamav-milter.pid|" \
+        -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
+        -e "s|.*\(User\) .*|\1 clamav|" \
+        -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \
+        -e "s|^\#\(LogTime\).*|\1 yes|" \
+        -e "s|.*\(\ClamdSocket\) .*|\1 unix:/run/clamav/clamd.sock|" \
+        "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
+    exit 1 && \
+    ctest -V || echo "Continuing with failed tests!"
+
+FROM registry.hub.docker.com/library/alpine:latest
+
+RUN apk add --no-cache \
+        fts \
+        json-c \
+        libbz2 \
+        libcurl \
+        libltdl \
+        libmilter \
+        libstdc++ \
+        libxml2 \
+        ncurses-libs \
+        pcre2 \
+        tini \
+        zlib \
+    && \
+    addgroup -S "clamav" && \
+    adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -S "clamav" && \
+    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav"
+
+COPY --from=builder "/clamav" "/"
+COPY "./dockerfiles/clamdcheck.sh" "/usr/local/bin/"
+COPY "./dockerfiles/docker-entrypoint.sh" "/init"
+
+ENTRYPOINT [ "/init" ]

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,261 @@
+# ClamAV in Docker
+
+ClamAV can be run within a Docker container. This provides isolation from other
+processes by running it in a containerized environment. If new or unfamiliar
+with docker, containers or cgroups see [docker.com](https://www.docker.com).
+
+## Building the ClamAV image
+
+While it is recommended to pull the image from our
+[docker hub registry](https://hub.docker.com/u/clamav/clamav), some may want
+to build the image locally instead. All that is needed is
+```console
+docker build --tag "clamav:TICKET-123" .
+```
+in the current directory. This will build the ClamAV image and tag it with
+the name "clamav:TICKET-123". Any name can generally be used and it is this
+name that needs to be referred to later when running the image.
+
+## Running clamd
+
+To run `clamd` in a docker container, first, an image  either has to be built
+or pulled from a docker registry. To pull ClamAV from the official docker hub
+registry, the following command can be used.
+
+> _Note_: Pulling is not always required, as `docker run` also pulls the image
+> if it does not yet exist and `docker run --pull` will always pull beforehand
+> to ensure the most up-to-date container is being used.
+
+```console
+docker run \
+       --interactive \
+       --name "clam_container_01" \
+       --rm \
+       --tty \
+       "myclamav" --help
+```
+
+The above creates an interactive container with the current tty connected to
+it. This is optional but useful when getting started as it allows one to
+directly see the output and, in the case of `clamd`, send ctrl-c to close the
+container. The `--rm` parameter ensures the container is cleaned up again after
+it exists and the `--name` parameter names the container, so it can be
+referenced through other (docker) commands, as several containers of the same
+image "myclamav" can be started without conflicts.
+
+## Running clam(d)scan
+
+Scanning files using `clamscan` or `clamdscan` is possible in various ways with
+docker. This section briefly describes them, but the other sections of this
+document are best read before hand to better understand some of the concepts.
+
+One important aspect is however to realize that docker by default does not have
+access to any of the hosts files. And so to scan these within docker, they need
+to be volume mounted to be made accessible.
+
+For example, running the container with these arguments ...
+```console
+       --volume '/path/to/scan:/scandir'
+```
+... would make the hosts file/directory `/path/to/scan` available in the
+container as `/scandir` and thus invoking `clamscan` would thus be done on
+`/scandir`.
+
+Note that while technically possible to run either scanners via `docker exec`
+this is not described as it is unlikely the container has access to the files
+to be scanned.
+
+### clamscan
+
+Using `clamscan` outside of the docker container is how normally `clamscan` is
+invoked. To make use of the available shared dockerized resources however, it
+is possible to expose the virus database and share that for example. E.g. it
+could be possible to run a docker container with only `freshclamd` and share
+the virus database directory `/var/lib/clamav`. This could be useful for file
+servers for example, where only `clamscan` is installed on the host, and
+`freshclam` is managed in a docker container.
+
+> _Note_: Running `freshclamd` separated from `clamd` is less recommended,
+> unless the `clamd` socket is shared with `freshclam` as `freshclam` would
+> not be able to inform `clamd` of database updates.
+
+### Dockerized clamscan
+
+To run `clamscan` in a docker container, the docker container can be invoked
+as:
+```console
+docker run \
+       --interactive \
+       --rm \
+       --tty \
+       --volume '/path/to/scan:/scandir' \
+       "myclamav" clamscan /scandir
+```
+This would pull the virus database using `freshclam`, run the scan and cleanup.
+
+> _Note_: This is very inefficient when done often, as the complete database is
+> downloaded on each invocation.
+
+### clamdscan
+
+As with `clamscan`, `clamdscan` can also be run when installed on the host, by
+connecting to the dockerized `clamd`. This can be done by either pointing
+`clamdscan` to the exposed TCP/UDP port or unix socket.
+
+### Dockerized clamdscan
+
+Running both `clamd` and `clamdscan` is also easily possible, as all that is
+needed is the shared socket between the two containers. The only cavaet here
+is to mount the files to be scaned in the container that is expected to run
+`clamdscan`.
+
+For example:
+```console
+docker run \
+       --interactive \
+       --rm \
+       --tty \
+       --volume '/path/to/scan:/scandir' \
+       --volume '/var/lib/docker/data/clamav/sockets/:/run/clamav/'
+       "myclamav" clamdscan /scandir
+```
+
+## Controlling the container
+
+The ClamAV container actually runs both `freshclamd` and `clamd` by default.
+Optionally available to the container is also ClamAV's milter. To control the
+behavior of the services started within the container, the following flags can
+be passed to the `docker run` command with the `--environment` parameter.
+
+* CLAMAV_NO_CLAMD [true|**false**] Do not start `clamd` (default: start `clamd`)
+* CLAMAV_NO_FRESHCLAMD [true|**false**] Do not start `freshclamd` (default: start `freshclamd`)
+* CLAMAV_NO_MILTERD [**true**|false] Do not start `clamav-milter` (default: nomilter)
+* CLAMD_STARTUP_TIMEOUT [integer] Seconds to wait for `clamd` to start (default: 1800)
+* FRESHCLAM_CHECKS [integer] `freshclam` daily update frequency (default: once per day)
+
+So to additionally also enable `clamav-milter`, the following flag can be added:
+```console
+       --environment 'CLAMAV_NO_MILTERED=false'
+```
+
+Further more, all of the configuration files that live in `/etc/clamav` can be
+overridden by doing a volume-mount to the specific file. The following argument
+can be added for this purpose. The example uses the entire configuration
+directory, but this can be supplied multiple times if individual files deem to
+be replaced.
+```console
+       --volume '/full/path/to/clamav/:/etc/clamav'
+```
+
+> _Note_: Even when disabling `freshclamd`, `freshclam` will always run at
+> least once during container startup if there is no virus database. While not
+> recommended, the virus database location itself `/var/lib/clamav/` could be
+> a persistent docker volume. This however is slightly more advanced and out of
+> scope of this document.
+
+## Connecting to the container
+
+### Executing commands within a running container
+
+To connect to a running ClamAV container, `docker exec` can be used to run a
+command on an already running container. To do so, the name needs to be either
+obtained from `docker ps` or supplied during container start via the `--name`
+parameter. The most interesting command in this case can be `clamdtop`.
+```console
+docker exec --interactive --tty "clamav_container_01" clamdtop
+```
+Alternatively, a shell can be started to inspect and run commands within the
+container as well.
+```console
+docker exec --interactive --tty "clamav_container_01" /bin/sh
+```
+
+### Unix sockets
+
+The default socket for `clamd` is located inside the container as
+`/run/clamav/clamd.sock` and can be connected to when exposed via a docker
+volume mount. To ensure, that `clamd` within the container can freely create
+and remove the socket, the path for the socket is to be volume-mounted, to
+expose it for others on the same host to use. The following volume can be used
+for this purpose. Do ensure that the directory on the host actually exists and
+clamav inside the container has permission to access it.
+Caution is required when managing permissions, as incorrect permission could
+open clamd for anyone on the host system.
+```console
+       --volume '/var/lib/docker/data/clamav/sockets/:/run/clamav/'
+```
+
+With the socket exposed to the host, any other service can now talk to `clamd`
+as well. If for example `clamdtop` where installed on the local host, calling
+```console
+clamdtop "/var/lib/docker/data/clamav/sockets/clamd.sock"
+```
+should work just fine. Likewise, running `clamdtop` in a different container,
+but sharing the socket will equally work. While `clamdtop` works well as an
+example here, it is of course important to realize, this can also be used to
+connect a mail server to `clamd`.
+
+### TCP
+
+While `clamd` and `clamav-milter` will listen on the default TCP ports as per
+configuration directives, docker does not expose these by default to the host.
+Only within  containers can these ports be accessed. To expose, or publish,
+these ports to the host, and thus potentially over the (inter)network, the
+`--publish` (or `--publish-all`) flag to `docker run` can be used. While more
+advanced/secure mappings can be done as per documentation, the basic way is to
+`--publish [<host_port>:]<container_port>` to make the port available to the
+host.
+```console
+       --publish 73310:3310 \
+       --publish 7357
+```
+The above would thus publish the milter port 3310 as 73310 on the host and the
+clamd port 7357 as a random to the host. The random port can be inspected via
+`docker ps`.
+
+> **Warning** extreme caution is to be taken when using `clamd` over TCP as
+> there are no protections on that level. All traffic is un-encrypted. Extra
+> care is to be taken when using TCP communications.
+
+## Virus database
+
+The virus database in `/var/lib/clamav` is by default unique to each container
+and thus is normally not shared. For simple setups this is fine, where only one
+instance of `clamd` is expected to run in a dockerized environment. However
+some use cases may want to efficiently share the database. To do so, the
+`docker volume` command can be used to create a persistent virus database.
+
+## Container clamd healthcheck
+
+Docker has the ability to run simple `ping` checks on services running inside
+containers. If `clamd` is running inside the container, docker will on
+occasion send a `ping` to `clamd` on the default port and wait for the pong
+from `clamd`. If `clamd` fails to respond, docker will treat this as an error.
+The healthcheck results can be viewed with `docker inspect`.
+
+## Performance
+
+The performance impact of running `clamd` in docker is negligible. Docker is
+in essence just a wrapper around Linux's cgroups and cgroups can be thought of
+as `chroot` or FreeBSD's `jail`. All code is executed on the host without any
+translation. Docker does however do some isolation (through cgroups) to isolate
+the various systems somewhat.
+
+Of course, nothing in life is free, and so there is some overhead. Disk-space
+being the most prominent one. The docker container might have some duplication
+of files for example between the host and the container. Further more, also RAM
+memory may be duplicated for each instance, as there is no RAM-deduplication.
+Both of which can be solved on the host however. A filesystem that supports
+disk-deduplication and a memory manager that does RAM-deduplication.
+
+The base container in itself is already very small ~16 MiB, at the time of this
+writing, this cost is still very tiny, where the advantages are very much worth
+the cost in general.
+
+The container including the virus database is about ~240 MiB at the time of
+this writing.
+
+## Bandwidth
+
+Please, be kind when using 'free' bandwidth. Both for the virus databases
+but also the docker registry.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ to get started!
 
 ## Installation Instructions
 
+### Docker
+
+ClamAV can be run using Docker, see [README.Docker.md](README.Docker.md) and
+our images on [docker hub](https://hub.docker.com/r/clamav/clamav).
+
 #### Build from Source
 
 For compile and install instructions with CMake, please see

--- a/clamav-config.h.cmake.in
+++ b/clamav-config.h.cmake.in
@@ -74,10 +74,10 @@
 
 #ifndef _WIN32
 /* Path to virus database directory. */
-#define DATADIR "@CMAKE_INSTALL_PREFIX@/@DATABASE_DIRECTORY@"
+#define DATADIR "@DATADIR@"
 
 /* where to look for the config file */
-#define CONFDIR "@CMAKE_INSTALL_PREFIX@/@APP_CONFIG_DIRECTORY@"
+#define CONFDIR "@CONFDIR@"
 #endif
 
 /* Have sys/fanotify.h */

--- a/clamd/clamav-daemon.service.in
+++ b/clamd/clamav-daemon.service.in
@@ -3,8 +3,8 @@ Description=Clam AntiVirus userspace daemon
 Documentation=man:clamd(8) man:clamd.conf(5) https://www.clamav.net/documents/
 Requires=clamav-daemon.socket
 # Check for database existence
-ConditionPathExistsGlob=@DBDIR@/main.{c[vl]d,inc}
-ConditionPathExistsGlob=@DBDIR@/daily.{c[vl]d,inc}
+ConditionPathExistsGlob=@DATADIR@/main.{c[vl]d,inc}
+ConditionPathExistsGlob=@DATADIR@/daily.{c[vl]d,inc}
 
 [Service]
 ExecStart=@prefix@/sbin/clamd --foreground=true

--- a/clamd/clamav-daemon.socket.in
+++ b/clamd/clamav-daemon.socket.in
@@ -2,8 +2,8 @@
 Description=Socket for Clam AntiVirus userspace daemon
 Documentation=man:clamd(8) man:clamd.conf(5) https://www.clamav.net/documents/
 # Check for database existence
-ConditionPathExistsGlob=@DBDIR@/main.{c[vl]d,inc}
-ConditionPathExistsGlob=@DBDIR@/daily.{c[vl]d,inc}
+ConditionPathExistsGlob=@DATADIR@/main.{c[vl]d,inc}
+ConditionPathExistsGlob=@DATADIR@/daily.{c[vl]d,inc}
 
 [Socket]
 ListenStream=/run/clamav/clamd.ctl

--- a/database/Makefile.am
+++ b/database/Makefile.am
@@ -20,7 +20,7 @@
 #  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
 EXTRA_DIST = main.cvd daily.cvd
-DBINST = @DBDIR@
+DBINST = @DATADIR@
 CLAMAVUSER = @CLAMAVUSER@
 CLAMAVGROUP = @CLAMAVGROUP@
 

--- a/dockerfiles/clamdcheck.sh
+++ b/dockerfiles/clamdcheck.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+if [ "${CLAMAV_NO_CLAMD:-}" != "false" ]; then
+	if [ "$(echo "PING" | nc localhost 3310)" != "PONG" ]; then
+		echo "ERROR: Unable to contact server"
+		exit 1
+	fi
+
+	echo "Clamd is up"
+fi
+
+exit 0

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -1,0 +1,80 @@
+#!/sbin/tini /bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021 Olliver Schinagl <oliver@schinagl.nl>
+# Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+if [ ! -d "/run/clamav" ]; then
+	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+fi
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt 0 ] && \
+   [ "${1#-}" = "${1}" ] && \
+   command -v "${1}" > "/dev/null" 2>&1; then
+	# Ensure healthcheck always passes
+	CLAMAV_NO_CLAMD="true" exec "${@}"
+else
+	if [ "${#}" -ge 1 ] && \
+	   [ "${1#-}" != "${1}" ]; then
+		# If an argument starts with "-" pass it to clamd specifically
+		exec clamd "${@}"
+	fi
+	# else default to running clamav's servers
+
+	# Help tiny-init a little
+	mkdir -p "/run/lock"
+	ln -f -s "/run/lock" "/var/lock"
+
+	# Ensure we have some virus data, otherwise clamd refuses to start
+	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
+		echo "Updating initial database"
+		freshclam --foreground --stdout
+	fi
+
+	if [ "${CLAMAV_NO_CLAMD:-}" != "true" ]; then
+		echo "Starting ClamAV"
+		if [ -S "/run/clamav/clamd.sock" ]; then
+			unlink "/run/clamav/clamd.sock"
+		fi
+		clamd --foreground &
+		while [ ! -S "/run/clamav/clamd.sock" ]; do
+			if [ "${_timeout:=0}" -gt "${CLAMD_STARTUP_TIMEOUT:=1800}" ]; then
+				echo
+				echo "Failed to start clamd"
+				exit 1
+			fi
+			printf "\r%s" "Socket for clamd not found yet, retrying (${_timeout}/${CLAMD_STARTUP_TIMEOUT}) ..."
+			sleep 1
+			_timeout="$((_timeout + 1))"
+		done
+		echo "socket found, clamd started."
+	fi
+
+	if [ "${CLAMAV_NO_FRESHCLAMD:-}" != "true" ]; then
+		echo "Starting Freshclamd"
+		freshclam \
+		          --checks="${FRESHCLAM_CHECKS:-1}" \
+		          --daemon \
+		          --foreground \
+		          --stdout \
+		          --user="clamav" \
+			  &
+	fi
+
+	if [ "${CLAMAV_NO_MILTERD:-}" != "true" ]; then
+		echo "Starting clamav milterd"
+		clamav-milter &
+	fi
+
+	# Wait forever (or until canceled)
+	exec tail -f "/dev/null"
+fi
+
+exit 0

--- a/dockerfiles/update_db_image.sh
+++ b/dockerfiles/update_db_image.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2021 Olliver Schinagl <oliver@schinagl.nl>
+# Copyright (C) 2021 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+set -eu
+
+DEF_CLAMAV_DOCKER_IMAGE="clamav/clamav"
+DEF_DOCKER_REGISTRY="registry.hub.docker.com"
+
+
+usage()
+{
+	echo "Usage: ${0} [OPTIONS]"
+	echo "Update docker images with latest clamav database."
+	echo "    -h  Print this usage"
+	echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
+	echo "    -p  Password for docker registry (file or string) [CLAMAV_DOCKER_PASSWD]"
+	echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
+	echo "    -t  Tag(s) to update (default: all tags)"
+	echo "    -u  Username for docker registry [CLAMAV_DOCKER_USER]"
+	echo
+	echo "Options that can also be passed in environment variables listed between [BRACKETS]."
+}
+
+init()
+{
+	if [ -z "${clamav_docker_user:-}" ] ||
+           [ -z "${clamav_docker_passwd:-}" ]; then
+		echo "No username or password set, skipping login"
+		return
+	fi
+
+	docker --version
+
+	if [ -f "${clamav_docker_passwd}" ]; then
+		_passwd="$(cat "${clamav_docker_passwd}")"
+	fi
+	echo "${_passwd:-${clamav_docker_passwd}}" | \
+	docker login \
+	             --password-stdin \
+	             --username "${clamav_docker_user}" \
+	             "${docker_registry}"
+}
+
+cleanup()
+{
+	if [ -z "${clamav_docker_user:-}" ]; then
+		echo "No username set, skipping logout"
+		return
+	fi
+
+	docker logout "${docker_registry:-}"
+}
+
+docker_tags_get()
+{
+	if [ -n "${clamav_docker_tags:-}" ]; then
+		return
+	fi
+
+	_tags="$(wget -q -O - "https://${docker_registry}/v1/repositories/${clamav_docker_image}/tags" |
+	         sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' | \
+		 tr '}' '\n' | \
+		 sed -n -e 's|.*name:\(.*\)$|\1|p')"
+
+	for _tag in ${_tags}; do
+		if [ "${_tag%%_base}" != "${_tag}" ]; then
+			clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
+		fi
+	done
+}
+
+clamav_db_update()
+{
+	if [ -z "${clamav_docker_tags:-}" ]; then
+		echo "No tags to update with, cannot continue."
+		exit 1
+	fi
+
+	for _tag in ${clamav_docker_tags}; do
+		{
+			echo "FROM ${docker_registry}/${clamav_docker_image}:${_tag}"
+			echo "RUN freshclam --foreground --stdout"
+		} | docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_image}:${_tag%%_base}" -
+		docker image push "${docker_registry}/${clamav_docker_image}:${_tag%%_base}"
+	done
+}
+
+main()
+{
+	_start_time="$(date "+%s")"
+
+	while getopts ":hi:p:r:t:u:" _options; do
+		case "${_options}" in
+		h)
+			usage
+			exit 0
+			;;
+		i)
+			clamav_docker_image="${OPTARG}"
+			;;
+		p)
+			clamav_docker_passwd="${OPTARG}"
+			;;
+		r)
+			docker_registry="${OPTARG}"
+			;;
+		t)
+			clamav_docker_tag="${OPTARG}"
+			;;
+		u)
+			clamav_docker_user="${OPTARG}"
+			;;
+		:)
+			e_err "Option -${OPTARG} requires an argument."
+			exit 1
+			;;
+		?)
+			e_err "Invalid option: -${OPTARG}"
+			exit 1
+			;;
+		esac
+	done
+	shift "$((OPTIND - 1))"
+
+	clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
+	clamav_docker_passwd="${clamav_docker_passwd:-${CLAMAV_DOCKER_PASSWD:-}}"
+	clamav_docker_tag="${clamav_docker_tag:-}"
+	clamav_docker_user="${clamav_docker_user:-${CLAMAV_DOCKER_USER:-}}"
+	docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
+
+	init
+
+	docker_tags_get
+	clamav_db_update
+
+	echo "==============================================================================="
+	echo "Build report for $(date -u)"
+	echo
+	echo "Updated database for image tags ..."
+	echo "${clamav_docker_tags:-}"
+	echo
+	echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
+	echo "==============================================================================="
+
+	cleanup
+}
+
+main "${@}"
+
+exit 0

--- a/docs/man/freshclam.conf.5.in
+++ b/docs/man/freshclam.conf.5.in
@@ -64,7 +64,7 @@ Default: disabled
 \fBDatabaseDirectory STRING\fR
 Path to a directory containing database files.
 .br
-Default: @DBDIR@
+Default: @DATADIR@
 .TP
 \fBForeground BOOL\fR
 Don't fork into background.

--- a/m4/reorganization/dbdir.m4
+++ b/m4/reorganization/dbdir.m4
@@ -1,4 +1,4 @@
-AC_ARG_WITH([dbdir], 
+AC_ARG_WITH([dbdir],
 [AS_HELP_STRING([--with-dbdir@<:@=path@:>@], [path to virus database directory])],
 db_dir="$withval", db_dir="_default_")
 
@@ -14,5 +14,5 @@ then
 fi
 
 AC_DEFINE_UNQUOTED([DATADIR],"$db_dir", [Path to virus database directory.])
-DBDIR="$db_dir"
-AC_SUBST([DBDIR])
+DATADIR="$db_dir"
+AC_SUBST([DATADIR])


### PR DESCRIPTION
This merge request adds the ability to offer clamd as a dockerized component. WIth the existing clamav docker hub group (https://hub.docker.com/u/clamav) makes it possible to have an official docker image to be used in cloud solutions.

There are some 'gotya's' in the scripts with regards to variables to make the image work in several situations to follow docker's guidelines as much as possible. E.g. by the default, the container starts all daemons, which can be disabled via environment variables. It's quite reasonable to expect for example milterd to be pretty much by many. However it is also not very uncommon, to wanting to use this container to run individual commands, e.g. to manually run a command.