### PR TITLE
Fix systemd error message.

### DIFF
--- a/clamd/clamav-daemon.service.in
+++ b/clamd/clamav-daemon.service.in
@@ -10,7 +10,6 @@ ConditionPathExistsGlob=@DBDIR@/daily.{c[vl]d,inc}
 ExecStart=@prefix@/sbin/clamd --foreground=true
 # Reload the database
 ExecReload=/bin/kill -USR2 $MAINPID
-StandardOutput=syslog
 TimeoutStartSec=420
 
 [Install]

--- a/freshclam/clamav-freshclam.service.in
+++ b/freshclam/clamav-freshclam.service.in
@@ -8,7 +8,6 @@ After=network-online.target
 
 [Service]
 ExecStart=@prefix@/bin/freshclam -d --foreground=true
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix systemd error message. It is recorded in journald on my linux system and can be corrected by two modifications.

Recorded error messages:
usr/lib/systemd/system/clamav-freshclam.service:13: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
/usr/lib/systemd/system/clamav-daemon.service:13: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.

systemd version: systemd 246.3-1

Signed-off-by: Sven Rueß <github@sritd.de>