### PR TITLE
Fix stack buffer overflow with old curl

### DIFF
--- a/clamonacc/client/communication.c
+++ b/clamonacc/client/communication.c
@@ -86,7 +86,9 @@ int onas_sendln(CURL *curl, const void *line, size_t len, int64_t timeout)
     curlcode = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
 #else
     /* Use deprecated CURLINFO_LASTSOCKET option */
-    curlcode = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockfd);
+    long long_sockfd;
+    curlcode = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &long_sockfd);
+    sockfd = (curl_socket_t) long_sockfd;
 #endif
 
     if (CURLE_OK != curlcode) {
@@ -150,7 +152,9 @@ int onas_recvln(struct RCVLN *rcv_data, char **ret_bol, char **ret_eol, int64_t 
     rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_ACTIVESOCKET, &sockfd);
 #else
     /* Use deprecated CURLINFO_LASTSOCKET option */
-    rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_LASTSOCKET, &sockfd);
+    long long_sockfd;
+    rcv_data->curlcode = curl_easy_getinfo(rcv_data->curl, CURLINFO_LASTSOCKET, &long_sockfd);
+    sockfd = (curl_socket_t) long_sockfd;
 #endif
 
     if (CURLE_OK != rcv_data->curlcode) {


### PR DESCRIPTION
curl_easy_getinfo expects a long for CURLINFO_ACTIVESOCKET, but curl_socket_t is an int, which was causing a stack buffer overflow and crash:

```
# gdb --args clamonacc --foreground -v
GNU gdb (Debian 7.7.1+dfsg-5) 7.7.1
Copyright (C) 2014 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from clamonacc...Reading symbols from /usr/lib/debug//usr/bin/clamonacc...done.
done.
(gdb) r
Starting program: /usr/bin/clamonacc --foreground -v
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff394f700 (LWP 1553)]
[Thread 0x7ffff394f700 (LWP 1553) exited]
[New Thread 0x7ffff394f700 (LWP 1554)]
[Thread 0x7ffff394f700 (LWP 1554) exited]
ClamClient: client setup to scan via streaming
[New Thread 0x7ffff394f700 (LWP 1555)]
[Thread 0x7ffff394f700 (LWP 1555) exited]
Clamonacc: daemon is remote
[New Thread 0x7ffff394f700 (LWP 1556)]
ClamFanotif: kernel-level blocking feature disabled ...
ClamFanotif: max file size limited to 5242880 bytes
ClamScanQueue: initializing event queue consumer ... (5) threads in thread pool
[New Thread 0x7ffff2f42700 (LWP 1557)]
Clamonacc: beginning event loops
ClamFanotif: starting fanotify event loop with process id (1549) ... 
[New Thread 0x7ffff2741700 (LWP 1558)]
ClamInotif: starting inotify event loop ...
ClamInotif: dynamically determining directory hierarchy...
[New Thread 0x7ffff1f40700 (LWP 1559)]
[New Thread 0x7ffff153e700 (LWP 1560)]
[New Thread 0x7ffff0d3d700 (LWP 1561)]
[New Thread 0x7fffebfff700 (LWP 1562)]
ClamScanQueue: waiting to consume events ...
ClamInotif: watching '/home' (and all sub-directories)
ClamFanotif: attempting to feed consumer queue
ClamWorker: performing scanning on file '/home/osboxes/.bashrc'
ClamFanotif: attempting to feed consumer queue
ClamWorker: performing scanning on file '/home/osboxes/.bashrc'
ClamFanotif: attempting to feed consumer queue
ClamWorker: performing scanning on file '/home/osboxes/.bash_history'
ClamFanotif: attempting to feed consumer queue
ClamWorker: performing scanning on file '/home/osboxes/.bash_history'
[New Thread 0x7fffeb7fe700 (LWP 1564)]
[Thread 0x7fffeb7fe700 (LWP 1564) exited]
ClamFanotif: attempting to feed consumer queue
ClamWorker: performing scanning on file '/home/osboxes/.bash_history'
ClamFanotif: attempting to feed consumer queue
ClamFanotif: attempting to feed consumer queue
ClamFanotif: attempting to feed consumer queue
*** stack smashing detected ***: /usr/bin/clamonacc terminated
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x731af)[0x7ffff6fb61af]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x37)[0x7ffff703baa7]
/lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x0)[0x7ffff703ba70]
/usr/bin/clamonacc(+0x13cfa)[0x555555567cfa]
/usr/bin/clamonacc(+0x12ed4)[0x555555566ed4]
/usr/bin/clamonacc(+0x12c0d)[0x555555566c0d]
/usr/bin/clamonacc(+0x171b0)[0x55555556b1b0]
/usr/bin/clamonacc(+0x17548)[0x55555556b548]
/usr/bin/clamonacc(+0x17675)[0x55555556b675]
/usr/bin/clamonacc(+0x17ffe)[0x55555556bffe]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x8064)[0x7ffff72f6064]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x6d)[0x7ffff702b62d]
======= Memory map: ========
555555554000-55555558f000 r-xp 00000000 08:01 12349695                   /usr/bin/clamonacc
55555578e000-555555795000 r--p 0003a000 08:01 12349695                   /usr/bin/clamonacc
555555795000-555555796000 rw-p 00041000 08:01 12349695                   /usr/bin/clamonacc
555555796000-5555557d9000 rw-p 00000000 00:00 0                          [heap]
7fffd8000000-7fffd8021000 rw-p 00000000 00:00 0 
7fffd8021000-7fffdc000000 ---p 00000000 00:00 0 
7fffe0000000-7fffe002a000 rw-p 00000000 00:00 0 
7fffe002a000-7fffe4000000 ---p 00000000 00:00 0 
7fffe4000000-7fffe4259000 rw-p 00000000 00:00 0 
7fffe4259000-7fffe8000000 ---p 00000000 00:00 0 
7fffeaffe000-7fffeafff000 ---p 00000000 00:00 0 
7fffeafff000-7fffeb7ff000 rw-p 00000000 00:00 0 
7fffeb7ff000-7fffeb800000 ---p 00000000 00:00 0 
7fffeb800000-7fffec000000 rw-p 00000000 00:00 0 
7fffec000000-7fffec021000 rw-p 00000000 00:00 0 
7fffec021000-7ffff0000000 ---p 00000000 00:00 0 
7ffff0327000-7ffff033d000 r-xp 00000000 08:01 8519761                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7ffff033d000-7ffff053c000 ---p 00016000 08:01 8519761                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7ffff053c000-7ffff053d000 rw-p 00015000 08:01 8519761                    /lib/x86_64-linux-gnu/libgcc_s.so.1
7ffff053d000-7ffff053e000 ---p 00000000 00:00 0 
7ffff053e000-7ffff0d3e000 rw-p 00000000 00:00 0 
7ffff0d3e000-7ffff0d3f000 ---p 00000000 00:00 0 
7ffff0d3f000-7ffff1740000 rw-p 00000000 00:00 0 
7ffff1740000-7ffff1741000 ---p 00000000 00:00 0 
7ffff1741000-7ffff1f41000 rw-p 00000000 00:00 0 
7ffff1f41000-7ffff1f42000 ---p 00000000 00:00 0 
7ffff1f42000-7ffff2742000 rw-p 00000000 00:00 0 
7ffff2742000-7ffff2743000 ---p 00000000 00:00 0 
7ffff2743000-7ffff2f43000 rw-p 00000000 00:00 0 
7ffff2f43000-7ffff2f4e000 r-xp 00000000 08:01 8519697                    /lib/x86_64-linux-gnu/libnss_files-2.19.so
7ffff2f4e000-7ffff314d000 ---p 0000b000 08:01 8519697                    /lib/x86_64-linux-gnu/libnss_files-2.19.so
7ffff314d000-7ffff314e000 r--p 0000a000 08:01 8519697                    /lib/x86_64-linux-gnu/libnss_files-2.19.so
7ffff314e000-7ffff314f000 rw-p 0000b000 08:01 8519697                    /lib/x86_64-linux-gnu/libnss_files-2.19.so
7ffff314f000-7ffff3150000 ---p 00000000 00:00 0 
7ffff3150000-7ffff3950000 rw-p 00000000 00:00 0 
7ffff3950000-7ffff3957000 r-xp 00000000 08:01 12325070                   /usr/lib/x86_64-linux-gnu/libffi.so.6.0.2
7ffff3957000-7ffff3b57000 ---p 00007000 08:01 12325070                   /usr/lib/x86_64-linux-gnu/libffi.so.6.0.2
7ffff3b57000-7ffff3b58000 r--p 00007000 08:01 12325070                   /usr/lib/x86_64-linux-gnu/libffi.so.6.0.2
7ffff3b58000-7ffff3b59000 rw-p 00008000 08:01 12325070                   /usr/lib/x86_64-linux-gnu/libffi.so.6.0.2
7ffff3b59000-7ffff3b6a000 r-xp 00000000 08:01 8519749                    /lib/x86_64-linux-gnu/libgpg-error.so.0.13.0
7ffff3b6a000-7ffff3d69000 ---p 00011000 08:01 8519749                    /lib/x86_64-linux-gnu/libgpg-error.so.0.13.0
7ffff3d69000-7ffff3d6a000 r--p 00010000 08:01 8519749                    /lib/x86_64-linux-gnu/libgpg-error.so.0.13.0
7ffff3d6a000-7ffff3d6b000 rw-p 00011000 08:01 8519749                    /lib/x86_64-linux-gnu/libgpg-error.so.0.13.0
7ffff3d6b000-7ffff3d7c000 r-xp 00000000 08:01 12325489                   /usr/lib/x86_64-linux-gnu/libtasn1.so.6.3.2
7ffff3d7c000-7ffff3f7c000 ---p 00011000 08:01 12325489                   /usr/lib/x86_64-linux-gnu/libtasn1.so.6.3.2
7ffff3f7c000-7ffff3f7e000 r--p 00011000 08:01 12325489                   /usr/lib/x86_64-linux-gnu/libtasn1.so.6.3.2
7ffff3f7e000-7ffff3f7f000 rw-p 00013000 08:01 12325489                   /usr/lib/x86_64-linux-gnu/libtasn1.so.6.3.2
7ffff3f7f000-7ffff3fbb000 r-xp 00000000 08:01 12325095                   /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.0.0
7ffff3fbb000-7ffff41ba000 ---p 0003c000 08:01 12325095                   /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.0.0
7ffff41ba000-7ffff41c3000 r--p 0003b000 08:01 12325095                   /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.0.0
7ffff41c3000-7ffff41c5000 rw-p 00044000 08:01 12325095                   /usr/lib/x86_64-linux-gnu/libp11-kit.so.0.0.0
7ffff41c5000-7ffff41df000 r-xp 00000000 08:01 12324135                   /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
7ffff41df000-7ffff43df000 ---p 0001a000 08:01 12324135                   /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
7ffff43df000-7ffff43e0000 r--p 0001a000 08:01 12324135                   /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
7ffff43e0000-7ffff43e1000 rw-p 0001b000 08:01 12324135                   /usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25
7ffff43e1000-7ffff43f5000 r-xp 00000000 08:01 8519702                    /lib/x86_64-linux-gnu/libresolv-2.19.so
7ffff43f5000-7ffff45f4000 ---p 00014000 08:01 8519702                    /lib/x86_64-linux-gnu/libresolv-2.19.so
7ffff45f4000-7ffff45f5000 r--p 00013000 08:01 8519702                    /lib/x86_64-linux-gnu/libresolv-2.19.so
7ffff45f5000-7ffff45f6000 rw-p 00014000 08:01 8519702                    /lib/x86_64-linux-gnu/libresolv-2.19.so
7ffff45f6000-7ffff45f8000 rw-p 00000000 00:00 0 
7ffff45f8000-7ffff45fb000 r-xp 00000000 08:01 8522648                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7ffff45fb000-7ffff47fa000 ---p 00003000 08:01 8522648                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7ffff47fa000-7ffff47fb000 r--p 00002000 08:01 8522648                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7ffff47fb000-7ffff47fc000 rw-p 00003000 08:01 8522648                    /lib/x86_64-linux-gnu/libkeyutils.so.1.5
7ffff47fc000-7ffff4807000 r-xp 00000000 08:01 12324124                   /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7ffff4807000-7ffff4a06000 ---p 0000b000 08:01 12324124                   /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7ffff4a06000-7ffff4a07000 r--p 0000a000 08:01 12324124                   /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7ffff4a07000-7ffff4a08000 rw-p 0000b000 08:01 12324124                   /usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1
7ffff4a08000-7ffff4ae0000 r-xp 00000000 08:01 8519791                    /lib/x86_64-linux-gnu/libgcrypt.so.20.0.3
7ffff4ae0000-7ffff4ce0000 ---p 000d8000 08:01 8519791                    /lib/x86_64-linux-gnu/libgcrypt.so.20.0.3
7ffff4ce0000-7ffff4ce1000 r--p 000d8000 08:01 8519791                    /lib/x86_64-linux-gnu/libgcrypt.so.20.0.3
7ffff4ce1000-7ffff4cea000 rw-p 000d9000 08:01 8519791                    /lib/x86_64-linux-gnu/libgcrypt.so.20.0.3
7ffff4cea000-7ffff4d6b000 r-xp 00000000 08:01 12325088                   /usr/lib/x86_64-linux-gnu/libgmp.so.10.2.0
7ffff4d6b000-7ffff4f6b000 ---p 00081000 08:01 12325088                   /usr/lib/x86_64-linux-gnu/libgmp.so.10.2.0
7ffff4f6b000-7ffff4f6c000 r--p 00081000 08:01 12325088                   /usr/lib/x86_64-linux-gnu/libgmp.so.10.2.0
7ffff4f6c000-7ffff4f6d000 rw-p 00082000 08:01 12325088                   /usr/lib/x86_64-linux-gnu/libgmp.so.10.2.0
7ffff4f6d000-7ffff4f9d000 r-xp 00000000 08:01 12325090                   /usr/lib/x86_64-linux-gnu/libnettle.so.4.7
7ffff4f9d000-7ffff519d000 ---p 00030000 08:01 12325090                   /usr/lib/x86_64-linux-gnu/libnettle.so.4.7
7ffff519d000-7ffff519e000 r--p 00030000 08:01 12325090                   /usr/lib/x86_64-linux-gnu/libnettle.so.4.7
7ffff519e000-7ffff519f000 rw-p 00031000 08:01 12325090                   /usr/lib/x86_64-linux-gnu/libnettle.so.4.7
7ffff519f000-7ffff51cd000 r-xp 00000000 08:01 12325092                   /usr/lib/x86_64-linux-gnu/libhogweed.so.2.5
7ffff51cd000-7ffff53cc000 ---p 0002e000 08:01 12325092                   /usr/lib/x86_64-linux-gnu/libhogweed.so.2.5
7ffff53cc000-7ffff53cd000 r--p 0002d000 08:01 12325092                   /usr/lib/x86_64-linux-gnu/libhogweed.so.2.5
7ffff53cd000-7ffff53ce000 rw-p 0002e000 08:01 12325092                   /usr/lib/x86_64-linux-gnu/libhogweed.so.2.5
7ffff53ce000-7ffff54e7000 r-xp 00000000 08:01 12324122                   /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28.43.4
7ffff54e7000-7ffff56e7000 ---p 00119000 08:01 12324122                   /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28.43.4
7ffff56e7000-7ffff56f1000 r--p 00119000 08:01 12324122                   /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28.43.4
7ffff56f1000-7ffff56f3000 rw-p 00123000 08:01 12324122                   /usr/lib/x86_64-linux-gnu/libgnutls-deb0.so.28.43.4
7ffff56f3000-7ffff56f4000 rw-p 00000000 00:00 0 
7ffff56f4000-7ffff570d000 r-xp 00000000 08:01 8519718                    /lib/x86_64-linux-gnu/libz.so.1.2.8
7ffff570d000-7ffff590d000 ---p 00019000 08:01 8519718                    /lib/x86_64-linux-gnu/libz.so.1.2.8
7ffff590d000-7ffff590e000 r--p 00019000 08:01 8519718                    /lib/x86_64-linux-gnu/libz.so.1.2.8
7ffff590e000-7ffff590f000 rw-p 0001a000 08:01 8519718                    /lib/x86_64-linux-gnu/libz.so.1.2.8
7ffff590f000-7ffff595c000 r-xp 00000000 08:01 12324140                   /usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.2.10.3
7ffff595c000-7ffff5b5c000 ---p 0004d000 08:01 12324140                   /usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.2.10.3
7ffff5b5c000-7ffff5b5e000 r--p 0004d000 08:01 12324140                   /usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.2.10.3
7ffff5b5e000-7ffff5b5f000 rw-p 0004f000 08:01 12324140                   /usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.2.10.3
7ffff5b5f000-7ffff5b61000 rw-p 00000000 00:00 0 
7ffff5b61000-7ffff5b6f000 r-xp 00000000 08:01 12324139                   /usr/lib/x86_64-linux-gnu/liblber-2.4.so.2.10.3
7ffff5b6f000-7ffff5d6e000 ---p 0000e000 08:01 12324139                   /usr/lib/x86_64-linux-gnu/liblber-2.4.so.2.10.3
7ffff5d6e000-7ffff5d6f000 r--p 0000d000 08:01 12324139                   /usr/lib/x86_64-linux-gnu/liblber-2.4.so.2.10.3
7ffff5d6f000-7ffff5d70000 rw-p 0000e000 08:01 12324139                   /usr/lib/x86_64-linux-gnu/liblber-2.4.so.2.10.3
7ffff5d70000-7ffff5d73000 r-xp 00000000 08:01 8519806                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7ffff5d73000-7ffff5f72000 ---p 00003000 08:01 8519806                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7ffff5f72000-7ffff5f73000 r--p 00002000 08:01 8519806                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7ffff5f73000-7ffff5f74000 rw-p 00003000 08:01 8519806                    /lib/x86_64-linux-gnu/libcom_err.so.2.1
7ffff5f74000-7ffff5fa2000 r-xp 00000000 08:01 12324126                   /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7ffff5fa2000-7ffff61a1000 ---p 0002e000 08:01 12324126                   /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7ffff61a1000-7ffff61a3000 r--p 0002d000 08:01 12324126                   /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7ffff61a3000-7ffff61a4000 rw-p 0002f000 08:01 12324126                   /usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1
7ffff61a4000-7ffff61a5000 rw-p 00000000 00:00 0 
7ffff61a5000-7ffff6269000 r-xp 00000000 08:01 12324130                   /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7ffff6269000-7ffff6469000 ---p 000c4000 08:01 12324130                   /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7ffff6469000-7ffff6476000 r--p 000c4000 08:01 12324130                   /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7ffff6476000-7ffff6479000 rw-p 000d1000 08:01 12324130                   /usr/lib/x86_64-linux-gnu/libkrb5.so.3.3
7ffff6479000-7ffff64c0000 r-xp 00000000 08:01 12324128                   /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7ffff64c0000-7ffff66c0000 ---p 00047000 08:01 12324128                   /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7ffff66c0000-7ffff66c2000 r--p 00047000 08:01 12324128                   /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7ffff66c2000-7ffff66c4000 rw-p 00049000 08:01 12324128                   /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2
7ffff66c4000-7ffff66ec000 r-xp 00000000 08:01 12329184                   /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
7ffff66ec000-7ffff68ec000 ---p 00028000 08:01 12329184                   /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
7ffff68ec000-7ffff68ed000 r--p 00028000 08:01 12329184                   /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
7ffff68ed000-7ffff68ee000 rw-p 00029000 08:01 12329184                   /usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1
7ffff68ee000-7ffff6909000 r-xp 00000000 08:01 12328975                   /usr/lib/x86_64-linux-gnu/librtmp.so.1
7ffff6909000-7ffff6b09000 ---p 0001b000 08:01 12328975                   /usr/lib/x86_64-linux-gnu/librtmp.so.1
7ffff6b09000-7ffff6b0a000 r--p 0001b000 08:01 12328975                   /usr/lib/x86_64-linux-gnu/librtmp.so.1
7ffff6b0a000-7ffff6b0b000 rw-p 0001c000 08:01 12328975                   /usr/lib/x86_64-linux-gnu/librtmp.so.1
7ffff6b0b000-7ffff6b3d000 r-xp 00000000 08:01 12324133                   /usr/lib/x86_64-linux-gnu/libidn.so.11.6.12
7ffff6b3d000-7ffff6d3d000 ---p 00032000 08:01 12324133                   /usr/lib/x86_64-linux-gnu/libidn.so.11.6.12
7ffff6d3d000-7ffff6d3e000 r--p 00032000 08:01 12324133                   /usr/lib/x86_64-linux-gnu/libidn.so.11.6.12
7ffff6d3e000-7ffff6d3f000 rw-p 00033000 08:01 12324133                   /usr/lib/x86_64-linux-gnu/libidn.so.11.6.12
7ffff6d3f000-7ffff6d42000 r-xp 00000000 08:01 8519691                    /lib/x86_64-linux-gnu/libdl-2.19.so
7ffff6d42000-7ffff6f41000 ---p 00003000 08:01 8519691                    /lib/x86_64-linux-gnu/libdl-2.19.so
7ffff6f41000-7ffff6f42000 r--p 00002000 08:01 8519691                    /lib/x86_64-linux-gnu/libdl-2.19.so
7ffff6f42000-7ffff6f43000 rw-p 00003000 08:01 8519691                    /lib/x86_64-linux-gnu/libdl-2.19.so
7ffff6f43000-7ffff70e4000 r-xp 00000000 08:01 8519688                    /lib/x86_64-linux-gnu/libc-2.19.so
7ffff70e4000-7ffff72e4000 ---p 001a1000 08:01 8519688                    /lib/x86_64-linux-gnu/libc-2.19.so
7ffff72e4000-7ffff72e8000 r--p 001a1000 08:01 8519688                    /lib/x86_64-linux-gnu/libc-2.19.so
7ffff72e8000-7ffff72ea000 rw-p 001a5000 08:01 8519688                    /lib/x86_64-linux-gnu/libc-2.19.so
7ffff72ea000-7ffff72ee000 rw-p 00000000 00:00 0 
7ffff72ee000-7ffff7306000 r-xp 00000000 08:01 8519683                    /lib/x86_64-linux-gnu/libpthread-2.19.so
7ffff7306000-7ffff7505000 ---p 00018000 08:01 8519683                    /lib/x86_64-linux-gnu/libpthread-2.19.so
7ffff7505000-7ffff7506000 r--p 00017000 08:01 8519683                    /lib/x86_64-linux-gnu/libpthread-2.19.so
7ffff7506000-7ffff7507000 rw-p 00018000 08:01 8519683                    /lib/x86_64-linux-gnu/libpthread-2.19.so
7ffff7507000-7ffff750b000 rw-p 00000000 00:00 0 
7ffff750b000-7ffff757b000 r-xp 00000000 08:01 12348260                   /usr/lib/x86_64-linux-gnu/libcurl.so.4.3.0
7ffff757b000-7ffff777a000 ---p 00070000 08:01 12348260                   /usr/lib/x86_64-linux-gnu/libcurl.so.4.3.0
7ffff777a000-7ffff777d000 r--p 0006f000 08:01 12348260                   /usr/lib/x86_64-linux-gnu/libcurl.so.4.3.0
7ffff777d000-7ffff777e000 rw-p 00072000 08:01 12348260                   /usr/lib/x86_64-linux-gnu/libcurl.so.4.3.0
7ffff777e000-7ffff794c000 r-xp 00000000 08:01 12324103                   /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7ffff794c000-7ffff7b4b000 ---p 001ce000 08:01 12324103                   /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7ffff7b4b000-7ffff7b68000 r--p 001cd000 08:01 12324103                   /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7ffff7b68000-7ffff7b78000 rw-p 001ea000 08:01 12324103                   /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
7ffff7b78000-7ffff7b7b000 rw-p 00000000 00:00 0 
7ffff7b7b000-7ffff7bd2000 r-xp 00000000 08:01 12324104                   /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0
7ffff7bd2000-7ffff7dd2000 ---p 00057000 08:01 12324104                   /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0
7ffff7dd2000-7ffff7dd5000 r--p 00057000 08:01 12324104                   /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0
7ffff7dd5000-7ffff7ddb000 rw-p 0005a000 08:01 12324104                   /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0
7ffff7ddb000-7ffff7ddc000 rw-p 00000000 00:00 0 
7ffff7ddc000-7ffff7dfd000 r-xp 00000000 08:01 8519685                    /lib/x86_64-linux-gnu/ld-2.19.so
7ffff7fce000-7ffff7fdd000 rw-p 00000000 00:00 0 
7ffff7ff3000-7ffff7ff7000 rw-p 00000000 00:00 0 
7ffff7ff7000-7ffff7ffa000 r--p 00000000 00:00 0                          [vvar]
7ffff7ffa000-7ffff7ffc000 r-xp 00000000 00:00 0                          [vdso]
7ffff7ffc000-7ffff7ffd000 r--p 00020000 08:01 8519685                    /lib/x86_64-linux-gnu/ld-2.19.so
7ffff7ffd000-7ffff7ffe000 rw-p 00021000 08:01 8519685                    /lib/x86_64-linux-gnu/ld-2.19.so
7ffff7ffe000-7ffff7fff000 rw-p 00000000 00:00 0 
7ffffffde000-7ffffffff000 rw-p 00000000 00:00 0                          [stack]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]

Program received signal SIGABRT, Aborted.
[Switching to Thread 0x7ffff153e700 (LWP 1560)]
0x00007ffff6f78067 in __GI_raise (sig=sig@entry=6)
    at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007ffff6f78067 in __GI_raise (sig=sig@entry=6)
    at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff6f79448 in __GI_abort () at abort.c:89
#2  0x00007ffff6fb61b4 in __libc_message (do_abort=do_abort@entry=2, 
    fmt=fmt@entry=0x7ffff70a8cb3 "*** %s ***: %s terminated\n")
    at ../sysdeps/posix/libc_fatal.c:175
#3  0x00007ffff703baa7 in __GI___fortify_fail (
    msg=msg@entry=0x7ffff70a8c9b "stack smashing detected")
    at fortify_fail.c:31
#4  0x00007ffff703ba70 in __stack_chk_fail () at stack_chk_fail.c:28
#5  0x0000555555567cfa in onas_recvln (rcv_data=rcv_data@entry=0x7ffff153a330, 
    ret_bol=ret_bol@entry=0x7ffff153a2e0, 
    ret_eol=ret_eol@entry=0x7ffff153a2f0, timeout=timeout@entry=5000)
    at ./client/communication.c:232
#6  0x0000555555566ed4 in onas_dsresult (curl=<optimized out>, 
    scantype=scantype@entry=2, maxstream=maxstream@entry=26214400, 
    filename=<optimized out>, 
    filename@entry=0x5555557aefe0 "/home/osboxes/.bashrc", fd=fd@entry=6, 
    timeout=timeout@entry=5000, printok=0x7ffff153d80c, errors=0x7ffff153dbd8, 
    ret_code=0x7ffff153dbdc) at ./client/protocol.c:268
#7  0x0000555555566c0d in onas_client_scan (tcpaddr=<optimized out>, 
    portnum=<optimized out>, scantype=2, maxstream=26214400, 
    fname=fname@entry=0x5555557aefe0 "/home/osboxes/.bashrc", fd=fd@entry=6, 
---Type <return> to continue, or q <return> to quit---
    timeout=5000, sb=..., infected=0x7ffff153dbd4, err=0x7ffff153dbd8, 
    ret_code=0x7ffff153dbdc) at ./client/client.c:434
#8  0x000055555556b1b0 in onas_scan_safe (ret_code=0x7ffff153dbdc, 
    err=0x7ffff153dbd8, infected=0x7ffff153dbd4, sb=..., 
    fname=0x5555557aefe0 "/home/osboxes/.bashrc", event_data=0x5555557ba560)
    at ./scan/thread.c:134
#9  onas_scan (ret_code=0x7ffff153dbdc, err=0x7ffff153dbd8, 
    infected=0x7ffff153dbd4, sb=..., 
    fname=0x5555557aefe0 "/home/osboxes/.bashrc", event_data=0x5555557ba560)
    at ./scan/thread.c:75
#10 onas_scan_thread_scanfile (event_data=event_data@entry=0x5555557ba560, 
    fname=fname@entry=0x5555557aefe0 "/home/osboxes/.bashrc", sb=..., 
    infected=infected@entry=0x7ffff153dbd4, err=err@entry=0x7ffff153dbd8, 
    ret_code=ret_code@entry=0x7ffff153dbdc) at ./scan/thread.c:172
#11 0x000055555556b548 in onas_scan_thread_handle_file (
    event_data=event_data@entry=0x5555557ba560, 
    pathname=0x5555557aefe0 "/home/osboxes/.bashrc") at ./scan/thread.c:292
#12 0x000055555556b675 in onas_scan_worker (arg=0x5555557ba560)
    at ./scan/thread.c:352
#13 0x000055555556bffe in thread_do (thread_p=<optimized out>)
    at ./c-thread-pool/thpool.c:366
#14 0x00007ffff72f6064 in start_thread (arg=0x7ffff153e700)
    at pthread_create.c:309
---Type <return> to continue, or q <return> to quit---
#15 0x00007ffff702b62d in clone ()
    at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
(gdb) 
```