### PR TITLE
Handle escaped forward slashes in regexes

### DIFF
--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -2611,7 +2611,19 @@ static int decodehex(const char *hexsig)
             mprintf("!missing regex expression terminator /\n");
             return -1;
         }
-        rlen = regex_end - wild - 1;
+
+        /* gotta make sure we treat escaped slashes */
+        for( i = tlen + 1; i < hexlen; i++ ) {
+            if( hexsig[ i ] == '/' && hexsig[ i - 1 ] != '\\' ) {
+                rlen = i - tlen - 1;
+                break;
+            }
+        }
+        if( i == hexlen ) {
+            mprintf( "!missing regex expression terminator /\n");
+            return -1;
+        }
+
         clen = hexlen - tlen - rlen - 2; /* 2 from regex boundaries '/' */
 
         /* get the trigger statement */


### PR DESCRIPTION
The decode-sigs function incorrectly handles escaped forward slashes in regexes. This code change finds the correct position of the regex_end, so CFLAGS will be printed correctly.

Current behavior:
```
echo 'Test.Sig;Target:4;0&1;3031;0/this is\/a test/m' | sigtool --decode-sigs
VIRUS NAME: Test.Sig
TDB: Target:4
LOGICAL EXPRESSION: 0&1
 * SUBSIG ID 0
 +-> OFFSET: ANY
 +-> SIGMOD: NONE
 +-> DECODED SUBSIGNATURE:
01
 * SUBSIG ID 1
 +-> OFFSET: ANY
 +-> SIGMOD: NONE
 +-> DECODED SUBSIGNATURE:
     +-> TRIGGER: 0
     +-> REGEX: this is\
     +-> CFLAGS: a test/m
```

Correct behavior with patched code:
```
echo 'Test.Sig;Target:4;0&1;3031;0/this is\/a test/m' | ./sigtool --decode-sigs
VIRUS NAME: Test.Sig
TDB: Target:4
LOGICAL EXPRESSION: 0&1
 * SUBSIG ID 0
 +-> OFFSET: ANY
 +-> SIGMOD: NONE
 +-> DECODED SUBSIGNATURE:
01
 * SUBSIG ID 1
 +-> OFFSET: ANY
 +-> SIGMOD: NONE
 +-> DECODED SUBSIGNATURE:
     +-> TRIGGER: 0
     +-> REGEX: this is\/a test
     +-> CFLAGS: m
```