### PR TITLE
Added %f to VirusEvent

### DIFF
--- a/clamd/clamd_others.c
+++ b/clamd/clamd_others.c
@@ -108,7 +108,7 @@ void virusaction(const char *filename, const char *virname,
     const struct optstruct *opt;
     char *buffer_file, *buffer_vir, *buffer_cmd, *path;
     const char *pt;
-    size_t i, j, v = 0, len;
+    size_t i, j, v = 0, f = 0, len;
     char *env[4];
 
     if (!(opt = optget(opts, "VirusEvent"))->enabled)
@@ -138,9 +138,14 @@ void virusaction(const char *filename, const char *virname,
         pt += 2;
         v++;
     }
+    pt = opt->strarg;
+    while ((pt = strstr(pt, "%f"))) {
+        pt += 2;
+        f++;
+    }
     len = strlen(opt->strarg);
     buffer_cmd =
-        (char *)calloc(len + v * strlen(virname) + 1, sizeof(char));
+        (char *)calloc(len + v * strlen(virname) + f * strlen(filename) + 1, sizeof(char));
     if (!buffer_cmd) {
         if (path)
             xfree(env[0]);
@@ -153,6 +158,10 @@ void virusaction(const char *filename, const char *virname,
         if (i + 1 < len && opt->strarg[i] == '%' && opt->strarg[i + 1] == 'v') {
             strcat(buffer_cmd, virname);
             j += strlen(virname);
+            i++;
+        } else if (i + 1 < len && opt->strarg[i] == '%' && opt->strarg[i + 1] == 'f') {
+            strcat(buffer_cmd, filename);
+            j += strlen(filename);
             i++;
         } else {
             buffer_cmd[j++] = opt->strarg[i];

--- a/docs/man/clamd.conf.5.in
+++ b/docs/man/clamd.conf.5.in
@@ -241,8 +241,9 @@ Default: yes
 .TP
 \fBVirusEvent COMMAND\fR
 Execute a command when a virus is found. In the command string %v will be
-replaced with the virus name. Additionally, two environment variables will
-be defined: $CLAM_VIRUSEVENT_FILENAME and $CLAM_VIRUSEVENT_VIRUSNAME.
+replaced with the virus name and %f will be replaced with the file name.
+Additionally, two environment variables will be defined: $CLAM_VIRUSEVENT_FILENAME
+and $CLAM_VIRUSEVENT_VIRUSNAME.
 \fR
 .br
 Default: disabled

--- a/etc/clamd.conf.sample
+++ b/etc/clamd.conf.sample
@@ -210,9 +210,11 @@ Example
 #ConcurrentDatabaseReload no
 
 # Execute a command when virus is found. In the command string %v will
-# be replaced with the virus name.
+# be replaced with the virus name and %f will be replaced with the file name.
+# Additionally, two environment variables will be defined: $CLAM_VIRUSEVENT_FILENAME
+# and $CLAM_VIRUSEVENT_VIRUSNAME.
 # Default: no
-#VirusEvent /usr/local/bin/send_sms 123456789 "VIRUS ALERT: %v"
+#VirusEvent /usr/local/bin/send_sms 123456789 "VIRUS ALERT: %v in %f"
 
 # Run as another user (clamd must be started by root for this option to work)
 # Default: don't drop privileges

--- a/shared/optparser.c
+++ b/shared/optparser.c
@@ -315,7 +315,7 @@ const struct clam_option __clam_options[] = {
 
     {"DisableCache", "disable-cache", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_CLAMSCAN, "This option allows you to disable clamd's caching feature.", "no"},
 
-    {"VirusEvent", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_CLAMD, "Execute a command when a virus is found. In the command string %v will be\nreplaced with the virus name. Additionally, two environment variables will\nbe defined: $CLAM_VIRUSEVENT_FILENAME and $CLAM_VIRUSEVENT_VIRUSNAME.", "/usr/bin/mailx -s \"ClamAV VIRUS ALERT: %v\" alert < /dev/null"},
+    {"VirusEvent", NULL, 0, CLOPT_TYPE_STRING, NULL, -1, NULL, 0, OPT_CLAMD, "Execute a command when a virus is found. In the command string %v will be\nreplaced with the virus name and %f will be replaced with the file name.\nAdditionally, two environment variables will be defined: $CLAM_VIRUSEVENT_FILENAME\nand $CLAM_VIRUSEVENT_VIRUSNAME.", "/usr/bin/mailx -s \"ClamAV VIRUS ALERT: %v\" alert < /dev/null"},
 
     {"ExitOnOOM", NULL, 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD, "Stop the daemon when libclamav reports an out of memory condition.", "yes"},
 

--- a/unit_tests/check_common.sh
+++ b/unit_tests/check_common.sh
@@ -383,7 +383,7 @@ test_clamd2() {
 
 test_clamd3() {
     test_start $1
-    echo "VirusEvent $abs_srcdir/virusaction-test.sh `pwd` \"Virus found: %v\"" >>test-clamd.conf
+    echo "VirusEvent $abs_srcdir/virusaction-test.sh `pwd` \"Virus found: %v in %f\"" >>test-clamd.conf
     echo "HeuristicScanPrecedence yes" >>test-clamd.conf
     start_clamd
     # Test HeuristicScanPrecedence feature
@@ -403,7 +403,7 @@ test_clamd3() {
     # Test VirusEvent feature
     run_clamdscan_fileonly $TOP/test/clam.exe
     test -f test-clamd.log || sleep 1
-    grep "Virus found: ClamAV-Test-File.UNOFFICIAL" test-clamd.log >/dev/null 2>/dev/null ||
+    grep "Virus found: ClamAV-Test-File.UNOFFICIAL in .*/clam.exe" test-clamd.log >/dev/null 2>/dev/null ||
 	{ cat test-clamd.log || true; die "Virusaction test failed"; }
 
     test_end $1

--- a/win32/conf_examples/clamd.conf.sample
+++ b/win32/conf_examples/clamd.conf.sample
@@ -183,9 +183,11 @@ TCPAddr 127.0.0.1
 #ConcurrentDatabaseReload no
 
 # Execute a command when virus is found. In the command string %v will
-# be replaced with the virus name.
+# be replaced with the virus name and %f will be replaced with the file name.
+# Additionally, two environment variables will be defined: $CLAM_VIRUSEVENT_FILENAME
+# and $CLAM_VIRUSEVENT_VIRUSNAME.
 # Default: no
-#VirusEvent "C:\example\SendEmail.ps1" email@addresscom "VIRUS ALERT: %v"
+#VirusEvent "C:\example\SendEmail.ps1" email@addresscom "VIRUS ALERT: %v in %f"
 
 # Run as another user (clamd must be started by root for this option to work)
 # Default: don't drop privileges


### PR DESCRIPTION
Hello,
While configuring the event trigger in clamd.conf, the only documented variable was "%v" for the virus name.
I considered it necessary to include also the file name, to avoid having to search for it in the log file. By looking into the code I found that there are 2 environment variables created which can be used in the VirusEvent configuration, they were just not documented in the example config file.
In this pull request I created a "%f" option (clamd source, test and doc) that can be used in the VirusEvent string as a placeholder for the file name and added the documentation for the 2 environment variables in the example config file.
Thank you for your consideration,
Vasile