### PR TITLE
autoit: Added 0x43 "VOLATILE" to autoit op 0x0  keywords

### DIFF
--- a/libclamav/autoit.c
+++ b/libclamav/autoit.c
@@ -454,7 +454,7 @@ const char *autoit_functions[] = {
     "WINWAITNOTACTIVE"};
 
 const char *autoit_keywords[] = {
-    "UNKNOWN_0",
+    "UNKNOWN_0", // "".
     "AND",
     "OR",
     "NOT",
@@ -497,7 +497,7 @@ const char *autoit_keywords[] = {
     "FALSE",
     "DEFAULT",
     "NULL",
-    "UNKNOWN_43",
+    "VOLATILE",
     "ENUM",
 };
 


### PR DESCRIPTION
Before it was listed as 'UNKNOWN_43' VOLATILE
about 'UNKNOWN_00' : 
currently Autoit interpreter 3.3.14.5 will turn keyword_ID 0x0 into an empty String.
However it is maybe good to keep it to "UNKNOWN_00" to see when keyword_ID 0x0 gets used.