### PR TITLE
clamdscan: Fix --fdpass -m & ExcludePath crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,21 @@ if(ENABLE_TESTS)
     # Used to generate the test files and for the application feature test framework
     find_package(Python3 REQUIRED)
 
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -m pip show pytest
+        RESULT_VARIABLE EXIT_CODE
+        ERROR_QUIET OUTPUT_QUIET
+    )
+
+    if (NOT ${EXIT_CODE} EQUAL 0)
+        message("Python3 package 'pytest' is not installed.")
+        message("Failed unit tests will be easier to read if you install pytest.")
+        message("Eg:  python3 -m pip install --user pytest")
+        set(Python3_TEST_PACKAGE "unittest;--verbose")
+    else()
+        set(Python3_TEST_PACKAGE "pytest;-v")
+    endif()
+
     # Check for valgrind. If it exists, we'll enable extra tests that use valgrind.
     if(C_LINUX)
         find_package(Valgrind)

--- a/libclamav/others.h
+++ b/libclamav/others.h
@@ -951,7 +951,7 @@ typedef int (*cli_ftw_pathchk)(const char *path, struct cli_ftw_cbdata *data);
  * which one it is.
  * If it is a file, it simply calls the callback once, otherwise recurses.
  */
-int cli_ftw(char *base, int flags, int maxdepth, cli_ftw_cb callback, struct cli_ftw_cbdata *data, cli_ftw_pathchk pathchk);
+cl_error_t cli_ftw(char *base, int flags, int maxdepth, cli_ftw_cb callback, struct cli_ftw_cbdata *data, cli_ftw_pathchk pathchk);
 
 const char *cli_strerror(int errnum, char *buf, size_t len);
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -260,48 +260,48 @@ set(ENVIRONMENT
 # Run a specific test like this:
 #                     `ctest -V -R libclamav_valgrind_test`
 #
-add_test(NAME libclamav COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;libclamav_test.py
+add_test(NAME libclamav COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};libclamav_test.py
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 set_property(TEST libclamav PROPERTY ENVIRONMENT ${ENVIRONMENT})
 if(Valgrind_FOUND)
-    add_test(NAME libclamav_valgrind COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;libclamav_test.py
+    add_test(NAME libclamav_valgrind COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};libclamav_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST libclamav_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
 endif()
 
 if(ENABLE_APP)
-    add_test(NAME clamscan COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;clamscan_test.py
+    add_test(NAME clamscan COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};clamscan_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST clamscan PROPERTY ENVIRONMENT ${ENVIRONMENT})
     if(Valgrind_FOUND)
-        add_test(NAME clamscan_valgrind COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;clamscan_test.py
+        add_test(NAME clamscan_valgrind COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};clamscan_test.py
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         set_property(TEST clamscan_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()
 
-    add_test(NAME clamd COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;clamd_test.py
+    add_test(NAME clamd COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};clamd_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST clamd PROPERTY ENVIRONMENT ${ENVIRONMENT})
     if(Valgrind_FOUND)
-        add_test(NAME clamd_valgrind COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;clamd_test.py
+        add_test(NAME clamd_valgrind COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};clamd_test.py
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         set_property(TEST clamd_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()
 
-    add_test(NAME freshclam COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;freshclam_test.py
+    add_test(NAME freshclam COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};freshclam_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST freshclam PROPERTY ENVIRONMENT ${ENVIRONMENT})
     if(Valgrind_FOUND)
-        add_test(NAME freshclam_valgrind COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;freshclam_test.py
+        add_test(NAME freshclam_valgrind COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};freshclam_test.py
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         set_property(TEST freshclam_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()
 
-    add_test(NAME sigtool COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;sigtool_test.py
+    add_test(NAME sigtool COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};sigtool_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set_property(TEST sigtool PROPERTY ENVIRONMENT ${ENVIRONMENT})
     if(Valgrind_FOUND)
-        add_test(NAME sigtool_valgrind COMMAND ${Python3_EXECUTABLE} -m;unittest;--verbose;sigtool_test.py
+        add_test(NAME sigtool_valgrind COMMAND ${Python3_EXECUTABLE} -m;${Python3_TEST_PACKAGE};sigtool_test.py
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         set_property(TEST sigtool_valgrind PROPERTY ENVIRONMENT ${ENVIRONMENT} VALGRIND=${Valgrind_EXECUTABLE})
     endif()

--- a/unit_tests/Run-GetLibs.ctest
+++ b/unit_tests/Run-GetLibs.ctest
@@ -1,1 +1,5 @@
-include(GetLibs-${CTEST_CONFIGURATION_TYPE}.ctest)
+if(CTEST_CONFIGURATION_TYPE)
+    include(GetLibs-${CTEST_CONFIGURATION_TYPE}.ctest)
+else()
+    message(FATAL_ERROR "\nCTest requires a config type argument on Windows.\n    Eg:  ctest -C Debug\n")
+endif()

--- a/unit_tests/check_clamd.c
+++ b/unit_tests/check_clamd.c
@@ -146,7 +146,11 @@ static void conn_teardown(void)
 
 #define NONEXISTENT PATHSEP "nonexistent\vfilename"
 
+#ifdef _WIN32
+#define NONEXISTENT_REPLY NONEXISTENT ": File path check failure: Invalid argument. ERROR"
+#else
 #define NONEXISTENT_REPLY NONEXISTENT ": File path check failure: No such file or directory. ERROR"
+#endif
 
 #ifndef _WIN32
 #define ACCDENIED OBJDIR PATHSEP "accdenied"
@@ -300,7 +304,7 @@ static void test_command(const char *cmd, size_t len, const char *extra, const c
     // For the same reasons, we can't expect the path to match exactly, so we'll
     // just make sure expect is found in recvdata and use the basename instead of the full path.
     expected_string_offset = CLI_STRNSTR(recvdata, expect, len);
-    ck_assert_msg(expected_string_offset != NULL, "Wrong reply for command %s: |%s|, expected: |%s|\n", cmd, recvdata, expect);
+    ck_assert_msg(expected_string_offset != NULL, "Wrong reply for command %s.\nReceived: \n%s\nExpected: \n%s\n", cmd, recvdata, expect);
     free(recvdata);
 }
 
@@ -439,7 +443,7 @@ START_TEST(test_instream)
                   len, expect_len, recvdata);
 
     rc = memcmp(recvdata, EXPECT_INSTREAM, expect_len);
-    ck_assert_msg(!rc, "Wrong reply for command INSTREAM: |%s|, expected: |%s|\n", recvdata, EXPECT_INSTREAM);
+    ck_assert_msg(!rc, "Wrong reply for command INSTREAM:\nReceived: \n%s\nExpected: \n%s\n", recvdata, EXPECT_INSTREAM);
     free(recvdata);
 
     conn_teardown();
@@ -517,7 +521,7 @@ static void tst_fildes(const char *cmd, size_t len, int fd,
                   len, expect_len, p, expect);
 
     rc = memcmp(p, expect, expect_len);
-    ck_assert_msg(!rc, "Wrong reply for command %s: |%s|, expected: |%s|\n", cmd, p, expect);
+    ck_assert_msg(!rc, "Wrong reply for command %s:\nReceived: \n%s\nExpected: \n%s\n", cmd, p, expect);
     free(recvdata);
     conn_teardown();
 }
@@ -835,7 +839,7 @@ static void test_idsession_commands(int split, int instream)
             ck_assert_msg(id <= j, "ID too big: %u, max: %u\n", id, j);
             q += 2;
             ck_assert_msg(NULL != strstr(q, replies[id - 1]),
-                          "Wrong ID reply for ID %u: %s, expected %s\n",
+                          "Wrong ID reply for ID %u:\nReceived: \n%s\nExpected: \n%s\n",
                           id,
                           q, replies[id - 1]);
             p = q + strlen(q) + 1;

--- a/unit_tests/check_clamd.c
+++ b/unit_tests/check_clamd.c
@@ -146,7 +146,7 @@ static void conn_teardown(void)
 
 #define NONEXISTENT PATHSEP "nonexistent\vfilename"
 
-#define NONEXISTENT_REPLY NONEXISTENT ": lstat() failed: No such file or directory. ERROR"
+#define NONEXISTENT_REPLY NONEXISTENT ": File path check failure: No such file or directory. ERROR"
 
 #ifndef _WIN32
 #define ACCDENIED OBJDIR PATHSEP "accdenied"

--- a/unit_tests/testcase.py
+++ b/unit_tests/testcase.py
@@ -4,7 +4,7 @@
 Wrapper for unittest to provide ClamAV specific test environment features.
 """
 
-from collections import namedtuple
+from typing import NamedTuple
 import hashlib
 import logging
 import os
@@ -30,6 +30,11 @@ CHUNK_SIZE = 100
 
 loggers = {}
 
+
+class CmdResult(NamedTuple):
+    ec: int
+    out: bytes
+    err: bytes
 
 class TestCase(unittest.TestCase):
     """
@@ -428,7 +433,7 @@ class TestCase(unittest.TestCase):
             "\n".join([error, res.err]),
             "\n".join([result, res.out]),
         )
-        return namedtuple("CmdResult", ["ec", "out", "err"])(code, result, error)
+        return CmdResult(code, result, error)
 
     def _taskkill(self, process, match_all=True):
         """Stop processes matching the given name.
@@ -461,7 +466,7 @@ class TestCase(unittest.TestCase):
             "\n".join([error, res.err]),
             "\n".join([result, res.out]),
         )
-        return namedtuple("CmdResult", ["ec", "out", "err"])(code, result, error)
+        return CmdResult(code, result, error)
 
     def stop_process(self, processes, options=["-9 -f"], sudo=False):
         """Stop all specified processes.
@@ -598,9 +603,7 @@ class Executor(object):
             self.terminated = True
             thread.join()
 
-        return namedtuple("CmdResult", ["ec", "out", "err"])(
-            self.code, self.result, self.error
-        )
+        return CmdResult(self.code, self.result, self.error)
 
     def __run(self, cmd, cwd=None, env_vars={}, interact=""):
         """Execute command in separate thread."""


### PR DESCRIPTION
If you set an ExcludePath regex in clamd.conf and then perform a
ClamDScan scan with --fdpass --multiscan, it will segfault.
The same issue also affects --fdpass --multiscan scans when using
ExcludePath when scanning a patch that doesn't exist.

The issue is that the filepath isn't being passed along for the path
exclusion regex match, resulting in a NULL deref.

This commit also fixes a possible memory leak if by duplicating the path
for the handle_entry() call _after_ the callback() runs, in case ret
isn't CL_SUCCESS and the function exits without every using the entry
structure or free'ing the copied filename.

The above work temporarily caused a test failure in check_clamd and a
valgrind failure in clamd for the nonexistent file test due to a minor
memory leak. This made it apparent that there were a few other nearby
possible memory leaks.

This commit fixes the above plus cleans up the error handling in clamd's
the file tree walk functions.