### PR TITLE
Github actions: add clang-format check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
@@ -10,7 +11,7 @@ AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: All
@@ -22,7 +23,7 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
   AfterControlStatement: false
@@ -55,24 +56,30 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
+    SortPriority:    0
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
+    SortPriority:    0
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    0
 IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
+IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false
@@ -108,18 +115,22 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
+SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-StatementMacros: 
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
 ...
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,65 @@
+name: clang-format
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+  pull_request:
+    branches:
+      - rel/*
+      - dev/*
+      - main
+
+jobs:
+  formatting-check:
+    name: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - check: 'libclamav'
+            exclude: '(iana_cctld|bytecode_api_|bytecode_hooks|rijndael|yara|inffixed|inflate|queue|tomsfastmath|nsis|7z|regex|c++|generated)'
+          - check: 'libfreshclam'
+            exclude: ''
+          - check: 'clamav-milter'
+            exclude: ''
+          - check: 'clambc'
+            exclude: ''
+          - check: 'clamconf'
+            exclude: ''
+          - check: 'clamd'
+            exclude: ''
+          - check: 'clamdscan'
+            exclude: ''
+          - check: 'clamdtop'
+            exclude: ''
+          - check: 'clamonacc'
+            exclude: '(c-thread-pool|fts|priv_fts)'
+          - check: 'clamscan'
+            exclude: ''
+          - check: 'clamsubmit'
+            exclude: ''
+          - check: 'freshclam'
+            exclude: ''
+          - check: 'libfreshclam'
+            exclude: ''
+          - check: 'shared'
+            exclude: ''
+          - check: 'sigtool'
+            exclude: ''
+          - check: 'examples'
+            exclude: ''
+          - check: 'win32/compat'
+            exclude: ''
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.3.0
+      with:
+        clang-format-version: '10'
+        check-path: ${{ matrix.path['check'] }}
+        exclude-regex: ${{ matrix.path['exclude'] }}

--- a/clamd/server-th.c
+++ b/clamd/server-th.c
@@ -210,8 +210,8 @@ static void *reload_th(void *arg)
     cl_error_t status = CL_EMALFDB;
 
     struct reload_th_t *rldata = arg;
-    struct cl_engine *engine = NULL;
-    unsigned int sigs = 0;
+    struct cl_engine *engine   = NULL;
+    unsigned int sigs          = 0;
     int retval;
 
     if (NULL == rldata || NULL == rldata->dbdir || NULL == rldata->settings) {

--- a/clamonacc/client/protocol.c
+++ b/clamonacc/client/protocol.c
@@ -95,18 +95,18 @@ static int onas_send_stream(CURL *curl, const char *filename, int fd, int64_t ti
         }
     }
 
-    if (FSTAT(fd, &statbuf)){
+    if (FSTAT(fd, &statbuf)) {
         logg("!onas_send_stream: Invalid args, bad file descriptor.\n");
         ret = -1;
         goto strm_out;
     }
 
-    if (S_ISDIR(statbuf.st_mode)){
+    if (S_ISDIR(statbuf.st_mode)) {
         ret = 0;
         goto strm_out;
     }
 
-    if ((uint64_t) statbuf.st_size > maxstream){
+    if ((uint64_t)statbuf.st_size > maxstream) {
         ret = 0;
         goto strm_out;
     }
@@ -116,25 +116,25 @@ static int onas_send_stream(CURL *curl, const char *filename, int fd, int64_t ti
         goto strm_out;
     }
 
-    len = statbuf.st_size;
+    len    = statbuf.st_size;
     buf[0] = htonl(len);
-    if (onas_sendln(curl, (const char *) buf, sizeof(uint32_t), timeout)){
+    if (onas_sendln(curl, (const char *)buf, sizeof(uint32_t), timeout)) {
         ret = -1;
         goto strm_out;
     }
 
-    while (bytesRead < len){
+    while (bytesRead < len) {
         ssize_t ret = read(fd, buf, sizeof(buf));
-        if (ret < 0){
+        if (ret < 0) {
             logg("!Failed to read from %s.\n", filename ? filename : "FD");
             ret = -1;
             goto strm_out;
-        } else if (0 == ret){
+        } else if (0 == ret) {
             break;
         }
         bytesRead += ret;
 
-        if (onas_sendln(curl, (const char *) buf, ret, timeout)) {
+        if (onas_sendln(curl, (const char *)buf, ret, timeout)) {
             ret = -1;
             goto strm_out;
         }

--- a/clamonacc/inotif/inotif.c
+++ b/clamonacc/inotif/inotif.c
@@ -712,7 +712,7 @@ static void onas_ddd_handle_in_create(struct onas_context *ctx,
                                       const char *path, const char *child_path, const struct inotify_event *event, int wd, uint64_t in_mask)
 {
 
-    if (!(event->mask & IN_ISDIR)){
+    if (!(event->mask & IN_ISDIR)) {
         return;
     }
 

--- a/libclamav/bytecode_api.h
+++ b/libclamav/bytecode_api.h
@@ -148,7 +148,7 @@ enum FunctionalityLevels {
     FUNC_LEVEL_0103      = 121, /**< LibClamAV release 0.103.0 */
     FUNC_LEVEL_0103_1    = 122, /**< LibClamAV release 0.103.1 */
 
-    FUNC_LEVEL_0104      = 131, /**< LibClamAV release 0.104.0 */
+    FUNC_LEVEL_0104 = 131, /**< LibClamAV release 0.104.0 */
 };
 
 /**

--- a/libclamav/hostid_internal.c
+++ b/libclamav/hostid_internal.c
@@ -129,7 +129,7 @@ struct device *get_devices(void)
         if (!(addr->ifa_addr))
             continue;
 
-        /*
+            /*
          * Even though POSIX (BSD) sockets define AF_LINK, Linux decided to be clever
          * and use AF_PACKET instead.
          */

--- a/libclamav/png.c
+++ b/libclamav/png.c
@@ -346,7 +346,7 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
                         cli_dbgmsg("PNG: zlib: inflate error: %d, Image decompression failed!\n", err);
                         inflateEnd(&zstrm);
                         zstrm_initialized = false;
-                        idat_state = PNG_IDAT_DECOMPRESSION_FAILED;
+                        idat_state        = PNG_IDAT_DECOMPRESSION_FAILED;
                         break;
                     }
                 }
@@ -355,7 +355,7 @@ cl_error_t cli_parsepng(cli_ctx *ctx)
                     cli_dbgmsg("  TOTAL decompressed:    %zu\n", decompressed_data_len);
                     inflateEnd(&zstrm);
                     zstrm_initialized = false;
-                    idat_state = PNG_IDAT_DECOMPRESSION_COMPLETE;
+                    idat_state        = PNG_IDAT_DECOMPRESSION_COMPLETE;
 
                     if (decompressed_data_len > image_size) {
                         status = cli_append_virus(ctx, "Heuristics.PNG.CVE-2010-1205");

--- a/libclamav/scanners.c
+++ b/libclamav/scanners.c
@@ -1506,8 +1506,7 @@ static cl_error_t vba_scandata(const unsigned char *data, size_t len, cli_ctx *c
     cli_ac_freedata(&tmdata);
     cli_ac_freedata(&gmdata);
 
-    return (ret != CL_CLEAN) ? ret : viruses_found ? CL_VIRUS
-                                                   : CL_CLEAN;
+    return (ret != CL_CLEAN) ? ret : viruses_found ? CL_VIRUS : CL_CLEAN;
 }
 
 #define min(x, y) ((x) < (y) ? (x) : (y))

--- a/sigtool/sigtool.c
+++ b/sigtool/sigtool.c
@@ -2614,14 +2614,14 @@ static int decodehex(const char *hexsig)
         }
 
         /* gotta make sure we treat escaped slashes */
-        for( i = tlen + 1; i < hexlen; i++ ) {
-            if( hexsig[ i ] == '/' && hexsig[ i - 1 ] != '\\' ) {
+        for (i = tlen + 1; i < hexlen; i++) {
+            if (hexsig[i] == '/' && hexsig[i - 1] != '\\') {
                 rlen = i - tlen - 1;
                 break;
             }
         }
-        if( i == hexlen ) {
-            mprintf( "!missing regex expression terminator /\n");
+        if (i == hexlen) {
+            mprintf("!missing regex expression terminator /\n");
             return -1;
         }
 

--- a/win32/compat/strptime.c
+++ b/win32/compat/strptime.c
@@ -285,14 +285,14 @@ LOCALE_PARAM_DECL
 #ifdef _NL_CURRENT
                     if (*decided != raw) {
                         if (match_string(_NL_CURRENT(LC_TIME, DAY_1 + cnt), rp)) {
-                            if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, DAY_1 + cnt),
-                                                        weekday_name[cnt]))
+                            if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, DAY_1 + cnt),
+                                                         weekday_name[cnt]))
                                 *decided = loc;
                             break;
                         }
                         if (match_string(_NL_CURRENT(LC_TIME, ABDAY_1 + cnt), rp)) {
-                            if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, ABDAY_1 + cnt),
-                                                        ab_weekday_name[cnt]))
+                            if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, ABDAY_1 + cnt),
+                                                         ab_weekday_name[cnt]))
                                 *decided = loc;
                             break;
                         }
@@ -317,14 +317,14 @@ LOCALE_PARAM_DECL
 #ifdef _NL_CURRENT
                     if (*decided != raw) {
                         if (match_string(_NL_CURRENT(LC_TIME, MON_1 + cnt), rp)) {
-                            if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, MON_1 + cnt),
-                                                        month_name[cnt]))
+                            if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, MON_1 + cnt),
+                                                         month_name[cnt]))
                                 *decided = loc;
                             break;
                         }
                         if (match_string(_NL_CURRENT(LC_TIME, ABMON_1 + cnt), rp)) {
-                            if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, ABMON_1 + cnt),
-                                                        ab_month_name[cnt]))
+                            if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, ABMON_1 + cnt),
+                                                         ab_month_name[cnt]))
                                 *decided = loc;
                             break;
                         }
@@ -351,7 +351,7 @@ LOCALE_PARAM_DECL
                         else
                             rp = rp_backup;
                     } else {
-                        if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, D_T_FMT), HERE_D_T_FMT))
+                        if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, D_T_FMT), HERE_D_T_FMT))
                             *decided = loc;
                         want_xday = 1;
                         break;
@@ -392,7 +392,7 @@ LOCALE_PARAM_DECL
                         else
                             rp = rp_backup;
                     } else {
-                        if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, D_FMT), HERE_D_FMT))
+                        if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, D_FMT), HERE_D_FMT))
                             *decided = loc;
                         want_xday = 1;
                         break;
@@ -480,8 +480,8 @@ LOCALE_PARAM_DECL
                         else
                             rp = rp_backup;
                     } else {
-                        if (*decided == not&&strcmp(_NL_CURRENT(LC_TIME, T_FMT_AMPM),
-                                                    HERE_T_FMT_AMPM))
+                        if (*decided == not &&strcmp(_NL_CURRENT(LC_TIME, T_FMT_AMPM),
+                                                     HERE_T_FMT_AMPM))
                             *decided = loc;
                         break;
                     }
@@ -1004,7 +1004,7 @@ LOCALE_PARAM_DECL
     enum ptime_locale_status decided;
 
 #ifdef _NL_CURRENT
-    decided = not;
+    decided = not ;
 #else
     decided = raw;
 #endif


### PR DESCRIPTION
Add check to make sure code is properly formatted.

I'm expecting this will fail because of 3rd party code we don't reformat under `libclamav`.

... might be a good excuse to migrate vendored code to an "external" or "3rdparty" directory. 🤔