### PR TITLE
clamdscan: Add null check to chkpath

### DIFF
--- a/clamdscan/proto.c
+++ b/clamdscan/proto.c
@@ -236,6 +236,10 @@ static int send_fdpass(int sockd, const char *filename)
 /* 0: scan, 1: skip */
 static int chkpath(const char *path)
 {
+    if(!path) {
+      return 1;
+    }
+
     const struct optstruct *opt;
 
     if ((opt = optget(clamdopts, "ExcludePath"))->enabled) {


### PR DESCRIPTION
I'm getting a segfault when running `clamdscan --fdpass --multiscan` with `ExcludePath` set.  Not sure why `path` is null, but adding a check here means it'll gets skipped instead of crashing